### PR TITLE
feat(orders): Orders bounded context — 9 stories

### DIFF
--- a/src/Orders/Domain/Aggregates/AggregateRoot.cs
+++ b/src/Orders/Domain/Aggregates/AggregateRoot.cs
@@ -1,0 +1,45 @@
+using Orders.Domain.Events;
+
+namespace Orders.Domain.Aggregates;
+
+/// <summary>
+/// Base class for aggregate roots. Provides identity, domain event collection,
+/// and concurrency control via an ETag.
+/// </summary>
+/// <typeparam name="TId">The type of the aggregate identifier.</typeparam>
+public abstract class AggregateRoot<TId> where TId : notnull
+{
+    private readonly List<IDomainEvent> _domainEvents = new();
+
+    /// <summary>
+    /// Unique identifier for the aggregate.
+    /// </summary>
+    public TId Id { get; protected set; } = default!;
+
+    /// <summary>
+    /// Cosmos DB ETag for optimistic concurrency control.
+    /// </summary>
+    public string? ETag { get; set; }
+
+    /// <summary>
+    /// Returns a read-only view of uncommitted domain events.
+    /// </summary>
+    public IReadOnlyList<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+
+    /// <summary>
+    /// Adds a domain event to the uncommitted events collection.
+    /// Called from within aggregate methods to record side effects.
+    /// </summary>
+    protected void AddDomainEvent(IDomainEvent domainEvent)
+    {
+        _domainEvents.Add(domainEvent);
+    }
+
+    /// <summary>
+    /// Clears all uncommitted domain events. Called after events have been dispatched.
+    /// </summary>
+    public void ClearDomainEvents()
+    {
+        _domainEvents.Clear();
+    }
+}

--- a/src/Orders/Domain/Aggregates/Order.cs
+++ b/src/Orders/Domain/Aggregates/Order.cs
@@ -1,0 +1,304 @@
+using Orders.Domain.Events;
+using Orders.Domain.Exceptions;
+using Orders.Domain.ValueObjects;
+
+namespace Orders.Domain.Aggregates;
+
+/// <summary>
+/// Aggregate root representing a customer's food order.
+/// Owns the full order lifecycle from placement through final delivery confirmation.
+/// </summary>
+public class Order : AggregateRoot<Guid>
+{
+    /// <summary>
+    /// Human-readable order number in format ORD-YYYYMMDD-sequential.
+    /// </summary>
+    public string OrderNumber { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Identifier of the customer who placed the order.
+    /// Also serves as the Cosmos DB partition key.
+    /// </summary>
+    public Guid CustomerId { get; private set; }
+
+    /// <summary>
+    /// Identifier of the restaurant fulfilling the order.
+    /// </summary>
+    public Guid RestaurantId { get; private set; }
+
+    /// <summary>
+    /// Current status of the order within its lifecycle state machine.
+    /// </summary>
+    public OrderStatus Status { get; private set; }
+
+    /// <summary>
+    /// Line items in the order. Maximum 20 items per order (ORD-R02).
+    /// </summary>
+    public List<OrderLineItem> LineItems { get; private set; } = new();
+
+    /// <summary>
+    /// Delivery destination for the order.
+    /// </summary>
+    public DeliveryAddress? DeliveryAddress { get; private set; }
+
+    /// <summary>
+    /// Financial summary: subtotal, delivery fee, and total.
+    /// </summary>
+    public OrderTotal? OrderTotal { get; private set; }
+
+    // --- State transition timestamps ---
+
+    /// <summary>Timestamp when the order was created (Draft).</summary>
+    public DateTimeOffset CreatedAt { get; private set; }
+
+    /// <summary>Timestamp when the customer placed the order.</summary>
+    public DateTimeOffset? PlacedAt { get; private set; }
+
+    /// <summary>Timestamp when the restaurant accepted the order.</summary>
+    public DateTimeOffset? AcceptedAt { get; private set; }
+
+    /// <summary>Timestamp when the restaurant began preparing the order.</summary>
+    public DateTimeOffset? PreparingAt { get; private set; }
+
+    /// <summary>Timestamp when the order was ready for driver pickup.</summary>
+    public DateTimeOffset? ReadyForPickupAt { get; private set; }
+
+    /// <summary>Timestamp when a driver picked up the order for delivery.</summary>
+    public DateTimeOffset? InDeliveryAt { get; private set; }
+
+    /// <summary>Timestamp when the order was delivered to the customer.</summary>
+    public DateTimeOffset? DeliveredAt { get; private set; }
+
+    /// <summary>Timestamp when the restaurant rejected the order.</summary>
+    public DateTimeOffset? RejectedAt { get; private set; }
+
+    /// <summary>Timestamp when the customer cancelled the order.</summary>
+    public DateTimeOffset? CancelledAt { get; private set; }
+
+    /// <summary>
+    /// Parameterless constructor for deserialization (Cosmos DB SDK).
+    /// </summary>
+    private Order() { }
+
+    /// <summary>
+    /// Creates a new Order aggregate. Used by the PlaceOrder flow (ORD-001).
+    /// Raises an OrderPlaced domain event upon creation.
+    /// </summary>
+    public Order(
+        Guid id,
+        string orderNumber,
+        Guid customerId,
+        Guid restaurantId,
+        List<OrderLineItem> lineItems,
+        DeliveryAddress deliveryAddress,
+        OrderTotal orderTotal)
+    {
+        Id = id;
+        OrderNumber = orderNumber;
+        CustomerId = customerId;
+        RestaurantId = restaurantId;
+        Status = OrderStatus.Placed;
+        LineItems = lineItems;
+        DeliveryAddress = deliveryAddress;
+        OrderTotal = orderTotal;
+        CreatedAt = DateTimeOffset.UtcNow;
+        PlacedAt = DateTimeOffset.UtcNow;
+
+        AddDomainEvent(new OrderPlaced
+        {
+            OrderId = Id,
+            OrderNumber = OrderNumber,
+            CustomerId = CustomerId,
+            RestaurantId = RestaurantId,
+            LineItems = LineItems.Select(li => new OrderPlacedLineItem
+            {
+                MenuItemId = li.MenuItemId,
+                MenuItemName = li.MenuItemName,
+                Quantity = li.Quantity,
+                UnitPrice = li.UnitPrice
+            }).ToList(),
+            DeliveryAddress = new OrderPlacedDeliveryAddress
+            {
+                Street = DeliveryAddress.Street,
+                City = DeliveryAddress.City,
+                Postcode = DeliveryAddress.Postcode,
+                Latitude = DeliveryAddress.Latitude,
+                Longitude = DeliveryAddress.Longitude
+            },
+            OrderTotal = OrderTotal.Total,
+            PlacedAt = PlacedAt!.Value
+        });
+    }
+
+    /// <summary>
+    /// Accepts the order. Transitions status from Placed to Accepted.
+    /// Called when an OrderAccepted event is received from the Restaurant context (ORD-005).
+    /// </summary>
+    /// <exception cref="InvalidOrderTransitionException">
+    /// Thrown when the order status is not Placed.
+    /// </exception>
+    public void Accept()
+    {
+        if (Status != OrderStatus.Placed)
+        {
+            throw new InvalidOrderTransitionException(Id, Status, OrderStatus.Accepted);
+        }
+
+        Status = OrderStatus.Accepted;
+        AcceptedAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Rejects the order. Transitions status from Placed to Rejected.
+    /// Called when an OrderRejected event is received from the Restaurant context (ORD-006).
+    /// </summary>
+    /// <param name="reason">The reason code for rejection.</param>
+    /// <exception cref="InvalidOrderTransitionException">
+    /// Thrown when the order status is not Placed.
+    /// </exception>
+    public void Reject(string reason)
+    {
+        if (Status != OrderStatus.Placed)
+        {
+            throw new InvalidOrderTransitionException(Id, Status, OrderStatus.Rejected);
+        }
+
+        Status = OrderStatus.Rejected;
+        RejectedAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Marks the order as ready for pickup. Transitions status from Accepted or Preparing to ReadyForPickup.
+    /// Called when an OrderReadyForPickup event is received from the Restaurant context (ORD-007).
+    /// Accepts transitions from both Accepted and Preparing since the Order context may not
+    /// have received an intermediate Preparing status update.
+    /// </summary>
+    /// <exception cref="InvalidOrderTransitionException">
+    /// Thrown when the order status is not Accepted or Preparing.
+    /// </exception>
+    public void MarkReadyForPickup()
+    {
+        if (Status != OrderStatus.Accepted && Status != OrderStatus.Preparing)
+        {
+            throw new InvalidOrderTransitionException(Id, Status, OrderStatus.ReadyForPickup);
+        }
+
+        Status = OrderStatus.ReadyForPickup;
+        ReadyForPickupAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Marks the order as in delivery. Transitions status from ReadyForPickup to InDelivery.
+    /// Called when a DriverAssigned event is received from the Delivery context (ORD-008).
+    /// </summary>
+    /// <exception cref="InvalidOrderTransitionException">
+    /// Thrown when the order status is not ReadyForPickup.
+    /// </exception>
+    public void MarkInDelivery()
+    {
+        if (Status != OrderStatus.ReadyForPickup)
+        {
+            throw new InvalidOrderTransitionException(Id, Status, OrderStatus.InDelivery);
+        }
+
+        Status = OrderStatus.InDelivery;
+        InDeliveryAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Marks the order as delivered. Transitions status from InDelivery to Delivered.
+    /// Called when a DeliveryCompleted event is received from the Delivery context (ORD-009).
+    /// This is the terminal happy-path transition for an order.
+    /// </summary>
+    /// <exception cref="InvalidOrderTransitionException">
+    /// Thrown when the order status is not InDelivery.
+    /// </exception>
+    public void MarkDelivered()
+    {
+        if (Status != OrderStatus.InDelivery)
+        {
+            throw new InvalidOrderTransitionException(Id, Status, OrderStatus.Delivered);
+        }
+
+        Status = OrderStatus.Delivered;
+        DeliveredAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Cancels the order. Only permitted while status is Placed (business rule ORD-R05).
+    /// Transitions status to Cancelled, records the cancellation timestamp,
+    /// and raises an OrderCancelled domain event.
+    /// </summary>
+    /// <exception cref="OrderCannotBeCancelledException">
+    /// Thrown when the order status is not Placed.
+    /// </exception>
+    public void Cancel()
+    {
+        if (Status != OrderStatus.Placed)
+        {
+            throw new OrderCannotBeCancelledException(Id, Status);
+        }
+
+        Status = OrderStatus.Cancelled;
+        CancelledAt = DateTimeOffset.UtcNow;
+
+        AddDomainEvent(new OrderCancelled
+        {
+            OrderId = Id,
+            OrderNumber = OrderNumber,
+            RestaurantId = RestaurantId,
+            CancelledAt = CancelledAt.Value
+        });
+    }
+}
+
+/// <summary>
+/// Value object representing one item in an order. References a menu item ID,
+/// menu item name, quantity (must be >= 1), and unit price (must be > 0.00).
+/// Immutable by design — all properties are init-only via the primary constructor.
+/// </summary>
+public record OrderLineItem
+{
+    public Guid MenuItemId { get; init; }
+    public string MenuItemName { get; init; } = string.Empty;
+    public int Quantity { get; init; }
+    public decimal UnitPrice { get; init; }
+
+    public OrderLineItem(Guid menuItemId, string menuItemName, int quantity, decimal unitPrice)
+    {
+        if (quantity < 1)
+            throw new ArgumentOutOfRangeException(nameof(quantity), quantity, "Quantity must be at least 1.");
+        if (unitPrice <= 0)
+            throw new ArgumentOutOfRangeException(nameof(unitPrice), unitPrice, "Unit price must be greater than zero.");
+
+        MenuItemId = menuItemId;
+        MenuItemName = menuItemName;
+        Quantity = quantity;
+        UnitPrice = unitPrice;
+    }
+
+    /// <summary>
+    /// Parameterless constructor for deserialization (Cosmos DB SDK).
+    /// </summary>
+    private OrderLineItem() { }
+}
+
+/// <summary>
+/// Value object for the customer's delivery location.
+/// Contains street, city, postcode, latitude, and longitude.
+/// </summary>
+public record DeliveryAddress(
+    string Street,
+    string City,
+    string Postcode,
+    double Latitude,
+    double Longitude);
+
+/// <summary>
+/// Value object for the order's financial summary:
+/// subtotal, delivery fee (fixed 2.99 GBP), and total.
+/// </summary>
+public record OrderTotal(
+    decimal Subtotal,
+    decimal DeliveryFee,
+    decimal Total);

--- a/src/Orders/Domain/Commands/CancelOrderCommand.cs
+++ b/src/Orders/Domain/Commands/CancelOrderCommand.cs
@@ -1,0 +1,26 @@
+using MediatR;
+
+namespace Orders.Domain.Commands;
+
+/// <summary>
+/// Command to cancel an existing order. Only permitted while the order status is Placed (ORD-R05).
+/// Dispatched from CancelOrderFunction to the CancelOrderCommandHandler via MediatR.
+/// </summary>
+public sealed record CancelOrderCommand : IRequest<CancelOrderResult>
+{
+    /// <summary>
+    /// Identifier of the order to cancel.
+    /// </summary>
+    public required Guid OrderId { get; init; }
+}
+
+/// <summary>
+/// Result returned on successful order cancellation.
+/// </summary>
+public sealed record CancelOrderResult
+{
+    public required Guid OrderId { get; init; }
+    public required string OrderNumber { get; init; }
+    public required string Status { get; init; }
+    public required DateTimeOffset CancelledAt { get; init; }
+}

--- a/src/Orders/Domain/Commands/CancelOrderCommandHandler.cs
+++ b/src/Orders/Domain/Commands/CancelOrderCommandHandler.cs
@@ -1,0 +1,45 @@
+using MediatR;
+using Orders.Domain.Exceptions;
+using Orders.Infrastructure.Repositories;
+
+namespace Orders.Domain.Commands;
+
+/// <summary>
+/// Handles the CancelOrderCommand by loading the order aggregate,
+/// delegating to the aggregate's Cancel() method, and persisting the result.
+/// No business logic lives here -- all rules are enforced inside the aggregate.
+/// </summary>
+public sealed class CancelOrderCommandHandler : IRequestHandler<CancelOrderCommand, CancelOrderResult>
+{
+    private readonly IOrderRepository _orderRepository;
+
+    public CancelOrderCommandHandler(IOrderRepository orderRepository)
+    {
+        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+    }
+
+    public async Task<CancelOrderResult> Handle(CancelOrderCommand request, CancellationToken cancellationToken)
+    {
+        // Load the order aggregate from the repository
+        var order = await _orderRepository.GetByIdAsync(request.OrderId, cancellationToken);
+
+        if (order is null)
+        {
+            throw new OrderNotFoundException(request.OrderId);
+        }
+
+        // Delegate to the aggregate -- Cancel() enforces ORD-R05 internally
+        order.Cancel();
+
+        // Persist the updated aggregate (repository also handles outbox pattern for domain events)
+        await _orderRepository.SaveAsync(order, cancellationToken);
+
+        return new CancelOrderResult
+        {
+            OrderId = order.Id,
+            OrderNumber = order.OrderNumber,
+            Status = order.Status.ToString(),
+            CancelledAt = order.CancelledAt!.Value
+        };
+    }
+}

--- a/src/Orders/Domain/Commands/PlaceOrderCommand.cs
+++ b/src/Orders/Domain/Commands/PlaceOrderCommand.cs
@@ -1,0 +1,114 @@
+using MediatR;
+
+namespace Orders.Domain.Commands;
+
+/// <summary>
+/// Command to place a new order. Validates business rules ORD-R01 through ORD-R04,
+/// calculates order total (ORD-R06), generates order number (ORD-R07), and raises
+/// the OrderPlaced domain event. Dispatched from PlaceOrderFunction via MediatR.
+/// </summary>
+public sealed record PlaceOrderCommand : IRequest<PlaceOrderResult>
+{
+    /// <summary>
+    /// Identifier of the customer placing the order.
+    /// </summary>
+    public required Guid CustomerId { get; init; }
+
+    /// <summary>
+    /// Identifier of the restaurant to order from.
+    /// </summary>
+    public required Guid RestaurantId { get; init; }
+
+    /// <summary>
+    /// Delivery address for the order.
+    /// </summary>
+    public required PlaceOrderDeliveryAddress DeliveryAddress { get; init; }
+
+    /// <summary>
+    /// Line items to include in the order.
+    /// </summary>
+    public required List<PlaceOrderLineItem> LineItems { get; init; }
+}
+
+/// <summary>
+/// Delivery address data from the PlaceOrder request.
+/// </summary>
+public sealed record PlaceOrderDeliveryAddress
+{
+    /// <summary>
+    /// Street address.
+    /// </summary>
+    public required string Street { get; init; }
+
+    /// <summary>
+    /// City name.
+    /// </summary>
+    public required string City { get; init; }
+
+    /// <summary>
+    /// Postal code.
+    /// </summary>
+    public required string Postcode { get; init; }
+
+    /// <summary>
+    /// Latitude coordinate. Required for delivery zone validation (ORD-R03).
+    /// </summary>
+    public double? Latitude { get; init; }
+
+    /// <summary>
+    /// Longitude coordinate. Required for delivery zone validation (ORD-R03).
+    /// </summary>
+    public double? Longitude { get; init; }
+}
+
+/// <summary>
+/// Line item data from the PlaceOrder request.
+/// </summary>
+public sealed record PlaceOrderLineItem
+{
+    /// <summary>
+    /// Menu item identifier.
+    /// </summary>
+    public required Guid MenuItemId { get; init; }
+
+    /// <summary>
+    /// Display name of the menu item.
+    /// </summary>
+    public required string MenuItemName { get; init; }
+
+    /// <summary>
+    /// Quantity ordered. Must be >= 1.
+    /// </summary>
+    public required int Quantity { get; init; }
+
+    /// <summary>
+    /// Unit price per item. Must be > 0.00.
+    /// </summary>
+    public required decimal UnitPrice { get; init; }
+}
+
+/// <summary>
+/// Result returned on successful order placement.
+/// </summary>
+public sealed record PlaceOrderResult
+{
+    /// <summary>
+    /// Unique order identifier.
+    /// </summary>
+    public required Guid OrderId { get; init; }
+
+    /// <summary>
+    /// Human-readable order number (format: ORD-YYYYMMDD-sequential).
+    /// </summary>
+    public required string OrderNumber { get; init; }
+
+    /// <summary>
+    /// Order status after placement (always "Placed").
+    /// </summary>
+    public required string Status { get; init; }
+
+    /// <summary>
+    /// Calculated order total including delivery fee.
+    /// </summary>
+    public required decimal OrderTotal { get; init; }
+}

--- a/src/Orders/Domain/Commands/PlaceOrderCommandHandler.cs
+++ b/src/Orders/Domain/Commands/PlaceOrderCommandHandler.cs
@@ -1,0 +1,126 @@
+using MediatR;
+using Orders.Domain.Aggregates;
+using Orders.Domain.Exceptions;
+using Orders.Infrastructure.Repositories;
+
+namespace Orders.Domain.Commands;
+
+/// <summary>
+/// Handles the PlaceOrderCommand by validating business rules (ORD-R01 through ORD-R04),
+/// creating the Order aggregate, and persisting it via the repository.
+/// Validation logic lives here because it validates the request data before aggregate creation.
+/// The aggregate constructor raises the OrderPlaced domain event.
+/// </summary>
+public sealed class PlaceOrderCommandHandler : IRequestHandler<PlaceOrderCommand, PlaceOrderResult>
+{
+    private const decimal DeliveryFee = 2.99m;
+    private const decimal MinimumSubtotal = 10.00m;
+    private const int MaxLineItems = 20;
+
+    private readonly IOrderRepository _orderRepository;
+
+    public PlaceOrderCommandHandler(IOrderRepository orderRepository)
+    {
+        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+    }
+
+    public async Task<PlaceOrderResult> Handle(PlaceOrderCommand request, CancellationToken cancellationToken)
+    {
+        // --- Validate request data (pre-aggregate-creation validation) ---
+        ValidateRequest(request);
+
+        // --- Build value objects ---
+        var lineItems = request.LineItems.Select(li => new OrderLineItem(
+            menuItemId: li.MenuItemId,
+            menuItemName: li.MenuItemName,
+            quantity: li.Quantity,
+            unitPrice: li.UnitPrice
+        )).ToList();
+
+        var deliveryAddress = new DeliveryAddress(
+            Street: request.DeliveryAddress.Street,
+            City: request.DeliveryAddress.City,
+            Postcode: request.DeliveryAddress.Postcode,
+            Latitude: request.DeliveryAddress.Latitude!.Value,
+            Longitude: request.DeliveryAddress.Longitude!.Value);
+
+        var subtotal = lineItems.Sum(li => li.Quantity * li.UnitPrice);
+        var orderTotal = new OrderTotal(subtotal, DeliveryFee, subtotal + DeliveryFee);
+
+        // --- Generate order number (ORD-R07) ---
+        var orderNumber = $"ORD-{DateTimeOffset.UtcNow:yyyyMMdd}-{Guid.NewGuid().ToString("N")[..6].ToUpperInvariant()}";
+
+        // --- Create the aggregate (constructor raises OrderPlaced event) ---
+        var order = new Order(
+            id: Guid.NewGuid(),
+            orderNumber: orderNumber,
+            customerId: request.CustomerId,
+            restaurantId: request.RestaurantId,
+            lineItems: lineItems,
+            deliveryAddress: deliveryAddress,
+            orderTotal: orderTotal);
+
+        // --- Persist the aggregate (repository handles outbox pattern for domain events) ---
+        await _orderRepository.SaveAsync(order, cancellationToken);
+
+        return new PlaceOrderResult
+        {
+            OrderId = order.Id,
+            OrderNumber = order.OrderNumber,
+            Status = order.Status.ToString(),
+            OrderTotal = order.OrderTotal!.Total
+        };
+    }
+
+    /// <summary>
+    /// Validates all PlaceOrder business rules before aggregate creation.
+    /// </summary>
+    private static void ValidateRequest(PlaceOrderCommand request)
+    {
+        // ORD-R04: customerId must be a non-empty Guid
+        if (request.CustomerId == Guid.Empty)
+        {
+            throw new InvalidOrderException("ORDER_INVALID_CUSTOMER",
+                "The customerId must be a valid, non-empty GUID.");
+        }
+
+        // ORD-R04: restaurantId must be a non-empty Guid
+        if (request.RestaurantId == Guid.Empty)
+        {
+            throw new InvalidOrderException("ORDER_INVALID_RESTAURANT",
+                "The restaurantId must be a valid, non-empty GUID.");
+        }
+
+        // ORD-R03: Delivery address must include latitude and longitude
+        if (request.DeliveryAddress.Latitude is null || request.DeliveryAddress.Longitude is null)
+        {
+            throw new InvalidOrderException("ORDER_INVALID_ADDRESS",
+                "Delivery address must include both latitude and longitude.");
+        }
+
+        // ORD-R02: Maximum 20 line items per order
+        if (request.LineItems.Count > MaxLineItems)
+        {
+            throw new InvalidOrderException("ORDER_TOO_MANY_ITEMS",
+                $"An order cannot contain more than {MaxLineItems} line items.");
+        }
+
+        // ORD-R03: Every line item must have quantity >= 1 and unitPrice > 0.00
+        foreach (var lineItem in request.LineItems)
+        {
+            if (lineItem.Quantity < 1 || lineItem.UnitPrice <= 0)
+            {
+                throw new InvalidOrderException("ORDER_INVALID_LINE_ITEM",
+                    $"Line item '{lineItem.MenuItemName}' has invalid quantity ({lineItem.Quantity}) or unit price ({lineItem.UnitPrice}). Quantity must be >= 1 and unit price must be > 0.00.");
+            }
+        }
+
+        // ORD-R01: Minimum order subtotal is GBP 10.00 (excluding delivery fee)
+        var subtotal = request.LineItems.Sum(li => li.Quantity * li.UnitPrice);
+        if (subtotal < MinimumSubtotal)
+        {
+            throw new InvalidOrderException("ORDER_MINIMUM_NOT_MET",
+                $"Order subtotal of {subtotal:F2} GBP is below the minimum of {MinimumSubtotal:F2} GBP.");
+        }
+    }
+}

--- a/src/Orders/Domain/Events/Consumed/DeliveryCompletedEvent.cs
+++ b/src/Orders/Domain/Events/Consumed/DeliveryCompletedEvent.cs
@@ -1,0 +1,71 @@
+namespace Orders.Domain.Events.Consumed;
+
+/// <summary>
+/// Event DTO for the DeliveryCompleted event consumed from the Delivery context
+/// via Service Bus topic delivery.completed.
+/// Matches the event envelope contract defined in FDD section 6.2.
+/// This is the terminal happy-path event for an order.
+/// </summary>
+public sealed record DeliveryCompletedEvent
+{
+    /// <summary>
+    /// Event type identifier (always "DeliveryCompleted").
+    /// </summary>
+    public string EventType { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Unique event identifier for idempotent processing.
+    /// </summary>
+    public Guid EventId { get; init; }
+
+    /// <summary>
+    /// Timestamp when the event occurred.
+    /// </summary>
+    public DateTimeOffset OccurredAt { get; init; }
+
+    /// <summary>
+    /// Source bounded context (always "Delivery").
+    /// </summary>
+    public string SourceContext { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Event-specific payload.
+    /// </summary>
+    public DeliveryCompletedPayload Payload { get; init; } = new();
+}
+
+/// <summary>
+/// Payload data for the DeliveryCompleted event.
+/// </summary>
+public sealed record DeliveryCompletedPayload
+{
+    /// <summary>
+    /// The delivery identifier from the Delivery context.
+    /// </summary>
+    public Guid DeliveryId { get; init; }
+
+    /// <summary>
+    /// The order identifier from the Orders context.
+    /// </summary>
+    public Guid OrderId { get; init; }
+
+    /// <summary>
+    /// The identifier of the driver who completed the delivery.
+    /// </summary>
+    public Guid DriverId { get; init; }
+
+    /// <summary>
+    /// Timestamp when the delivery was completed.
+    /// </summary>
+    public DateTimeOffset DeliveredAt { get; init; }
+
+    /// <summary>
+    /// Total minutes from OrderReadyForPickup to Delivered.
+    /// </summary>
+    public int TotalDeliveryMinutes { get; init; }
+
+    /// <summary>
+    /// Whether the 45-minute SLA was breached.
+    /// </summary>
+    public bool SlaBreached { get; init; }
+}

--- a/src/Orders/Domain/Events/Consumed/DriverAssignedEvent.cs
+++ b/src/Orders/Domain/Events/Consumed/DriverAssignedEvent.cs
@@ -1,0 +1,65 @@
+namespace Orders.Domain.Events.Consumed;
+
+/// <summary>
+/// Event DTO for the DriverAssigned event consumed from the Delivery context
+/// via Service Bus topic delivery.driver-assigned.
+/// Matches the event envelope contract defined in FDD section 6.2.
+/// </summary>
+public sealed record DriverAssignedEvent
+{
+    /// <summary>
+    /// Event type identifier (always "DriverAssigned").
+    /// </summary>
+    public string EventType { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Unique event identifier for idempotent processing.
+    /// </summary>
+    public Guid EventId { get; init; }
+
+    /// <summary>
+    /// Timestamp when the event occurred.
+    /// </summary>
+    public DateTimeOffset OccurredAt { get; init; }
+
+    /// <summary>
+    /// Source bounded context (always "Delivery").
+    /// </summary>
+    public string SourceContext { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Event-specific payload.
+    /// </summary>
+    public DriverAssignedPayload Payload { get; init; } = new();
+}
+
+/// <summary>
+/// Payload data for the DriverAssigned event.
+/// </summary>
+public sealed record DriverAssignedPayload
+{
+    /// <summary>
+    /// The delivery identifier from the Delivery context.
+    /// </summary>
+    public Guid DeliveryId { get; init; }
+
+    /// <summary>
+    /// The order identifier from the Orders context.
+    /// </summary>
+    public Guid OrderId { get; init; }
+
+    /// <summary>
+    /// The identifier of the assigned driver.
+    /// </summary>
+    public Guid DriverId { get; init; }
+
+    /// <summary>
+    /// Estimated minutes until delivery completion.
+    /// </summary>
+    public int EstimatedArrivalMinutes { get; init; }
+
+    /// <summary>
+    /// Timestamp when the driver was assigned.
+    /// </summary>
+    public DateTimeOffset AssignedAt { get; init; }
+}

--- a/src/Orders/Domain/Events/Consumed/OrderAcceptedEvent.cs
+++ b/src/Orders/Domain/Events/Consumed/OrderAcceptedEvent.cs
@@ -1,0 +1,60 @@
+namespace Orders.Domain.Events.Consumed;
+
+/// <summary>
+/// Event DTO for the OrderAccepted event consumed from the Restaurant context
+/// via Service Bus topic restaurant.order-accepted.
+/// Matches the event envelope contract defined in FDD section 6.2.
+/// </summary>
+public sealed record OrderAcceptedEvent
+{
+    /// <summary>
+    /// Event type identifier (always "OrderAccepted").
+    /// </summary>
+    public string EventType { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Unique event identifier for idempotent processing.
+    /// </summary>
+    public Guid EventId { get; init; }
+
+    /// <summary>
+    /// Timestamp when the event occurred.
+    /// </summary>
+    public DateTimeOffset OccurredAt { get; init; }
+
+    /// <summary>
+    /// Source bounded context (always "Restaurant").
+    /// </summary>
+    public string SourceContext { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Event-specific payload.
+    /// </summary>
+    public OrderAcceptedPayload Payload { get; init; } = new();
+}
+
+/// <summary>
+/// Payload data for the OrderAccepted event.
+/// </summary>
+public sealed record OrderAcceptedPayload
+{
+    /// <summary>
+    /// The order identifier from the Orders context.
+    /// </summary>
+    public Guid OrderId { get; init; }
+
+    /// <summary>
+    /// The restaurant identifier.
+    /// </summary>
+    public Guid RestaurantId { get; init; }
+
+    /// <summary>
+    /// Estimated preparation time in minutes provided by restaurant staff.
+    /// </summary>
+    public int EstimatedPrepMinutes { get; init; }
+
+    /// <summary>
+    /// Timestamp when the restaurant accepted the order.
+    /// </summary>
+    public DateTimeOffset AcceptedAt { get; init; }
+}

--- a/src/Orders/Domain/Events/Consumed/OrderReadyForPickupEvent.cs
+++ b/src/Orders/Domain/Events/Consumed/OrderReadyForPickupEvent.cs
@@ -1,0 +1,91 @@
+namespace Orders.Domain.Events.Consumed;
+
+/// <summary>
+/// Event DTO for the OrderReadyForPickup event consumed from the Restaurant context
+/// via Service Bus topic restaurant.order-ready.
+/// Matches the event envelope contract defined in FDD section 6.2.
+/// </summary>
+public sealed record OrderReadyForPickupEvent
+{
+    /// <summary>
+    /// Event type identifier (always "OrderReadyForPickup").
+    /// </summary>
+    public string EventType { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Unique event identifier for idempotent processing.
+    /// </summary>
+    public Guid EventId { get; init; }
+
+    /// <summary>
+    /// Timestamp when the event occurred.
+    /// </summary>
+    public DateTimeOffset OccurredAt { get; init; }
+
+    /// <summary>
+    /// Source bounded context (always "Restaurant").
+    /// </summary>
+    public string SourceContext { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Event-specific payload.
+    /// </summary>
+    public OrderReadyForPickupPayload Payload { get; init; } = new();
+}
+
+/// <summary>
+/// Payload data for the OrderReadyForPickup event.
+/// </summary>
+public sealed record OrderReadyForPickupPayload
+{
+    /// <summary>
+    /// The order identifier from the Orders context.
+    /// </summary>
+    public Guid OrderId { get; init; }
+
+    /// <summary>
+    /// The restaurant identifier.
+    /// </summary>
+    public Guid RestaurantId { get; init; }
+
+    /// <summary>
+    /// The restaurant's physical address for driver pickup.
+    /// </summary>
+    public RestaurantAddressPayload RestaurantAddress { get; init; } = new();
+
+    /// <summary>
+    /// Timestamp when the food was ready for pickup.
+    /// </summary>
+    public DateTimeOffset ReadyAt { get; init; }
+}
+
+/// <summary>
+/// Restaurant address data within the OrderReadyForPickup event payload.
+/// </summary>
+public sealed record RestaurantAddressPayload
+{
+    /// <summary>
+    /// Street address.
+    /// </summary>
+    public string Street { get; init; } = string.Empty;
+
+    /// <summary>
+    /// City name.
+    /// </summary>
+    public string City { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Postal code.
+    /// </summary>
+    public string Postcode { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Latitude coordinate.
+    /// </summary>
+    public double Latitude { get; init; }
+
+    /// <summary>
+    /// Longitude coordinate.
+    /// </summary>
+    public double Longitude { get; init; }
+}

--- a/src/Orders/Domain/Events/Consumed/OrderRejectedEvent.cs
+++ b/src/Orders/Domain/Events/Consumed/OrderRejectedEvent.cs
@@ -1,0 +1,65 @@
+namespace Orders.Domain.Events.Consumed;
+
+/// <summary>
+/// Event DTO for the OrderRejected event consumed from the Restaurant context
+/// via Service Bus topic restaurant.order-rejected.
+/// Matches the event envelope contract defined in FDD section 6.2.
+/// </summary>
+public sealed record OrderRejectedEvent
+{
+    /// <summary>
+    /// Event type identifier (always "OrderRejected").
+    /// </summary>
+    public string EventType { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Unique event identifier for idempotent processing.
+    /// </summary>
+    public Guid EventId { get; init; }
+
+    /// <summary>
+    /// Timestamp when the event occurred.
+    /// </summary>
+    public DateTimeOffset OccurredAt { get; init; }
+
+    /// <summary>
+    /// Source bounded context (always "Restaurant").
+    /// </summary>
+    public string SourceContext { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Event-specific payload.
+    /// </summary>
+    public OrderRejectedPayload Payload { get; init; } = new();
+}
+
+/// <summary>
+/// Payload data for the OrderRejected event.
+/// </summary>
+public sealed record OrderRejectedPayload
+{
+    /// <summary>
+    /// The order identifier from the Orders context.
+    /// </summary>
+    public Guid OrderId { get; init; }
+
+    /// <summary>
+    /// The restaurant identifier.
+    /// </summary>
+    public Guid RestaurantId { get; init; }
+
+    /// <summary>
+    /// Rejection reason code (e.g., RESTAURANT_CLOSED, ITEM_UNAVAILABLE, TOO_BUSY, OTHER).
+    /// </summary>
+    public string ReasonCode { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Menu item IDs that were unavailable (empty if not applicable).
+    /// </summary>
+    public List<Guid> UnavailableItemIds { get; init; } = new();
+
+    /// <summary>
+    /// Timestamp when the restaurant rejected the order.
+    /// </summary>
+    public DateTimeOffset RejectedAt { get; init; }
+}

--- a/src/Orders/Domain/Events/IDomainEvent.cs
+++ b/src/Orders/Domain/Events/IDomainEvent.cs
@@ -1,0 +1,17 @@
+namespace Orders.Domain.Events;
+
+/// <summary>
+/// Marker interface for domain events raised by aggregates.
+/// </summary>
+public interface IDomainEvent
+{
+    /// <summary>
+    /// Unique identifier for idempotent event processing.
+    /// </summary>
+    Guid EventId { get; }
+
+    /// <summary>
+    /// Timestamp when the event occurred.
+    /// </summary>
+    DateTimeOffset OccurredAt { get; }
+}

--- a/src/Orders/Domain/Events/OrderCancelled.cs
+++ b/src/Orders/Domain/Events/OrderCancelled.cs
@@ -1,0 +1,31 @@
+namespace Orders.Domain.Events;
+
+/// <summary>
+/// Domain event published to Service Bus topic orders.cancelled when a customer cancels an order.
+/// Consumed by Restaurant and Delivery contexts.
+/// </summary>
+public sealed record OrderCancelled : IDomainEvent
+{
+    public Guid EventId { get; init; } = Guid.NewGuid();
+    public DateTimeOffset OccurredAt { get; init; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Unique order identifier.
+    /// </summary>
+    public required Guid OrderId { get; init; }
+
+    /// <summary>
+    /// Human-readable order number (format: ORD-YYYYMMDD-sequential).
+    /// </summary>
+    public required string OrderNumber { get; init; }
+
+    /// <summary>
+    /// Restaurant identifier, used by downstream contexts to locate their local projection.
+    /// </summary>
+    public required Guid RestaurantId { get; init; }
+
+    /// <summary>
+    /// Timestamp of cancellation.
+    /// </summary>
+    public required DateTimeOffset CancelledAt { get; init; }
+}

--- a/src/Orders/Domain/Events/OrderPlaced.cs
+++ b/src/Orders/Domain/Events/OrderPlaced.cs
@@ -1,0 +1,108 @@
+namespace Orders.Domain.Events;
+
+/// <summary>
+/// Domain event published to Service Bus topic orders.placed when a customer places an order.
+/// Consumed by Restaurant context to create a RestaurantOrder and indirectly by Delivery context.
+/// </summary>
+public sealed record OrderPlaced : IDomainEvent
+{
+    public Guid EventId { get; init; } = Guid.NewGuid();
+    public DateTimeOffset OccurredAt { get; init; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Unique order identifier.
+    /// </summary>
+    public required Guid OrderId { get; init; }
+
+    /// <summary>
+    /// Human-readable order number (format: ORD-YYYYMMDD-sequential).
+    /// </summary>
+    public required string OrderNumber { get; init; }
+
+    /// <summary>
+    /// Identifier of the customer who placed the order.
+    /// </summary>
+    public required Guid CustomerId { get; init; }
+
+    /// <summary>
+    /// Identifier of the restaurant fulfilling the order.
+    /// </summary>
+    public required Guid RestaurantId { get; init; }
+
+    /// <summary>
+    /// Line items included in the order.
+    /// </summary>
+    public required List<OrderPlacedLineItem> LineItems { get; init; }
+
+    /// <summary>
+    /// Delivery address for the order.
+    /// </summary>
+    public required OrderPlacedDeliveryAddress DeliveryAddress { get; init; }
+
+    /// <summary>
+    /// Calculated order total including delivery fee.
+    /// </summary>
+    public required decimal OrderTotal { get; init; }
+
+    /// <summary>
+    /// Timestamp when the order was placed.
+    /// </summary>
+    public required DateTimeOffset PlacedAt { get; init; }
+}
+
+/// <summary>
+/// Line item data included in the OrderPlaced event payload.
+/// </summary>
+public sealed record OrderPlacedLineItem
+{
+    /// <summary>
+    /// Menu item identifier referenced by this line item.
+    /// </summary>
+    public required Guid MenuItemId { get; init; }
+
+    /// <summary>
+    /// Display name of the menu item.
+    /// </summary>
+    public required string MenuItemName { get; init; }
+
+    /// <summary>
+    /// Quantity ordered.
+    /// </summary>
+    public required int Quantity { get; init; }
+
+    /// <summary>
+    /// Unit price at the time of ordering.
+    /// </summary>
+    public required decimal UnitPrice { get; init; }
+}
+
+/// <summary>
+/// Delivery address data included in the OrderPlaced event payload.
+/// </summary>
+public sealed record OrderPlacedDeliveryAddress
+{
+    /// <summary>
+    /// Street address.
+    /// </summary>
+    public required string Street { get; init; }
+
+    /// <summary>
+    /// City name.
+    /// </summary>
+    public required string City { get; init; }
+
+    /// <summary>
+    /// Postal code.
+    /// </summary>
+    public required string Postcode { get; init; }
+
+    /// <summary>
+    /// Latitude coordinate of the delivery address.
+    /// </summary>
+    public required double Latitude { get; init; }
+
+    /// <summary>
+    /// Longitude coordinate of the delivery address.
+    /// </summary>
+    public required double Longitude { get; init; }
+}

--- a/src/Orders/Domain/Exceptions/InvalidOrderException.cs
+++ b/src/Orders/Domain/Exceptions/InvalidOrderException.cs
@@ -1,0 +1,26 @@
+namespace Orders.Domain.Exceptions;
+
+/// <summary>
+/// Thrown when order placement validation fails due to business rule violations
+/// (e.g., minimum order value not met, too many items, invalid address).
+/// Maps to HTTP 400 with the specific error code describing the validation failure.
+/// </summary>
+public sealed class InvalidOrderException : Exception
+{
+    /// <summary>
+    /// Machine-readable error code identifying the specific validation failure.
+    /// </summary>
+    public string ErrorCode { get; }
+
+    public InvalidOrderException(string errorCode, string message)
+        : base(message)
+    {
+        ErrorCode = errorCode;
+    }
+
+    public InvalidOrderException(string errorCode, string message, Exception innerException)
+        : base(message, innerException)
+    {
+        ErrorCode = errorCode;
+    }
+}

--- a/src/Orders/Domain/Exceptions/InvalidOrderTransitionException.cs
+++ b/src/Orders/Domain/Exceptions/InvalidOrderTransitionException.cs
@@ -1,0 +1,47 @@
+using Orders.Domain.ValueObjects;
+
+namespace Orders.Domain.Exceptions;
+
+/// <summary>
+/// Thrown when an invalid state transition is attempted on an Order aggregate.
+/// For Service Bus event handlers, this exception is caught, logged as a warning,
+/// and the event is discarded without rethrowing to prevent poison message scenarios.
+/// </summary>
+public sealed class InvalidOrderTransitionException : Exception
+{
+    /// <summary>
+    /// The order identifier.
+    /// </summary>
+    public Guid OrderId { get; }
+
+    /// <summary>
+    /// The current status of the order.
+    /// </summary>
+    public OrderStatus CurrentStatus { get; }
+
+    /// <summary>
+    /// The target status that was attempted.
+    /// </summary>
+    public OrderStatus TargetStatus { get; }
+
+    /// <summary>
+    /// Machine-readable error code.
+    /// </summary>
+    public string ErrorCode => "ORDER_INVALID_TRANSITION";
+
+    public InvalidOrderTransitionException(Guid orderId, OrderStatus currentStatus, OrderStatus targetStatus)
+        : base($"Order '{orderId}' cannot transition from '{currentStatus}' to '{targetStatus}'.")
+    {
+        OrderId = orderId;
+        CurrentStatus = currentStatus;
+        TargetStatus = targetStatus;
+    }
+
+    public InvalidOrderTransitionException(Guid orderId, OrderStatus currentStatus, OrderStatus targetStatus, Exception innerException)
+        : base($"Order '{orderId}' cannot transition from '{currentStatus}' to '{targetStatus}'.", innerException)
+    {
+        OrderId = orderId;
+        CurrentStatus = currentStatus;
+        TargetStatus = targetStatus;
+    }
+}

--- a/src/Orders/Domain/Exceptions/OrderCannotBeCancelledException.cs
+++ b/src/Orders/Domain/Exceptions/OrderCannotBeCancelledException.cs
@@ -1,0 +1,29 @@
+using Orders.Domain.ValueObjects;
+
+namespace Orders.Domain.Exceptions;
+
+/// <summary>
+/// Thrown when an order cancellation is attempted but the order is not in Placed status.
+/// Enforces business rule ORD-R05.
+/// Maps to HTTP 409 with error code ORDER_CANNOT_CANCEL.
+/// </summary>
+public sealed class OrderCannotBeCancelledException : Exception
+{
+    public Guid OrderId { get; }
+    public OrderStatus CurrentStatus { get; }
+    public string ErrorCode => "ORDER_CANNOT_CANCEL";
+
+    public OrderCannotBeCancelledException(Guid orderId, OrderStatus currentStatus)
+        : base($"Order '{orderId}' cannot be cancelled. Current status is '{currentStatus}'. Cancellation is only permitted when the order status is 'Placed'.")
+    {
+        OrderId = orderId;
+        CurrentStatus = currentStatus;
+    }
+
+    public OrderCannotBeCancelledException(Guid orderId, OrderStatus currentStatus, Exception innerException)
+        : base($"Order '{orderId}' cannot be cancelled. Current status is '{currentStatus}'. Cancellation is only permitted when the order status is 'Placed'.", innerException)
+    {
+        OrderId = orderId;
+        CurrentStatus = currentStatus;
+    }
+}

--- a/src/Orders/Domain/Exceptions/OrderNotFoundException.cs
+++ b/src/Orders/Domain/Exceptions/OrderNotFoundException.cs
@@ -1,0 +1,23 @@
+namespace Orders.Domain.Exceptions;
+
+/// <summary>
+/// Thrown when an order with the specified identifier cannot be found.
+/// Maps to HTTP 404 with error code ORDER_NOT_FOUND.
+/// </summary>
+public sealed class OrderNotFoundException : Exception
+{
+    public Guid OrderId { get; }
+    public string ErrorCode => "ORDER_NOT_FOUND";
+
+    public OrderNotFoundException(Guid orderId)
+        : base($"Order with ID '{orderId}' was not found.")
+    {
+        OrderId = orderId;
+    }
+
+    public OrderNotFoundException(Guid orderId, Exception innerException)
+        : base($"Order with ID '{orderId}' was not found.", innerException)
+    {
+        OrderId = orderId;
+    }
+}

--- a/src/Orders/Domain/Queries/GetOrderQuery.cs
+++ b/src/Orders/Domain/Queries/GetOrderQuery.cs
@@ -1,0 +1,84 @@
+using MediatR;
+
+namespace Orders.Domain.Queries;
+
+/// <summary>
+/// Query to retrieve a single order by its unique identifier.
+/// Dispatched from GetOrderFunction to the GetOrderQueryHandler via MediatR.
+/// This is a read-only operation — no state changes or domain events are produced.
+/// </summary>
+public sealed record GetOrderQuery : IRequest<GetOrderResponse>
+{
+    /// <summary>
+    /// Identifier of the order to retrieve.
+    /// </summary>
+    public required Guid OrderId { get; init; }
+}
+
+/// <summary>
+/// Response DTO containing the full order details including line items,
+/// current status, delivery address, financial totals, and all state
+/// transition timestamps.
+/// </summary>
+public sealed record GetOrderResponse
+{
+    public required Guid OrderId { get; init; }
+    public required string OrderNumber { get; init; }
+    public required Guid CustomerId { get; init; }
+    public required Guid RestaurantId { get; init; }
+    public required string Status { get; init; }
+    public required List<GetOrderLineItemResponse> LineItems { get; init; }
+    public required GetOrderDeliveryAddressResponse? DeliveryAddress { get; init; }
+    public required GetOrderTotalResponse? OrderTotal { get; init; }
+    public required GetOrderTimestampsResponse Timestamps { get; init; }
+}
+
+/// <summary>
+/// Line item details within a GetOrderResponse.
+/// </summary>
+public sealed record GetOrderLineItemResponse
+{
+    public required Guid MenuItemId { get; init; }
+    public required string MenuItemName { get; init; }
+    public required int Quantity { get; init; }
+    public required decimal UnitPrice { get; init; }
+}
+
+/// <summary>
+/// Delivery address details within a GetOrderResponse.
+/// </summary>
+public sealed record GetOrderDeliveryAddressResponse
+{
+    public required string Street { get; init; }
+    public required string City { get; init; }
+    public required string Postcode { get; init; }
+    public required double Latitude { get; init; }
+    public required double Longitude { get; init; }
+}
+
+/// <summary>
+/// Financial total details within a GetOrderResponse.
+/// </summary>
+public sealed record GetOrderTotalResponse
+{
+    public required decimal Subtotal { get; init; }
+    public required decimal DeliveryFee { get; init; }
+    public required decimal Total { get; init; }
+}
+
+/// <summary>
+/// All state transition timestamps for an order. Null timestamps indicate
+/// that the order has not yet reached that lifecycle stage.
+/// </summary>
+public sealed record GetOrderTimestampsResponse
+{
+    public required DateTimeOffset CreatedAt { get; init; }
+    public required DateTimeOffset? PlacedAt { get; init; }
+    public required DateTimeOffset? AcceptedAt { get; init; }
+    public required DateTimeOffset? PreparingAt { get; init; }
+    public required DateTimeOffset? ReadyForPickupAt { get; init; }
+    public required DateTimeOffset? InDeliveryAt { get; init; }
+    public required DateTimeOffset? DeliveredAt { get; init; }
+    public required DateTimeOffset? RejectedAt { get; init; }
+    public required DateTimeOffset? CancelledAt { get; init; }
+}

--- a/src/Orders/Domain/Queries/GetOrderQueryHandler.cs
+++ b/src/Orders/Domain/Queries/GetOrderQueryHandler.cs
@@ -1,0 +1,82 @@
+using MediatR;
+using Orders.Domain.Aggregates;
+using Orders.Domain.Exceptions;
+using Orders.Infrastructure.Repositories;
+
+namespace Orders.Domain.Queries;
+
+/// <summary>
+/// Handles the GetOrderQuery by loading the order aggregate from the repository
+/// and mapping it to a GetOrderResponse DTO. This is a pure read operation —
+/// no business logic, no state changes, no domain events.
+/// </summary>
+public sealed class GetOrderQueryHandler : IRequestHandler<GetOrderQuery, GetOrderResponse>
+{
+    private readonly IOrderRepository _orderRepository;
+
+    public GetOrderQueryHandler(IOrderRepository orderRepository)
+    {
+        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+    }
+
+    public async Task<GetOrderResponse> Handle(GetOrderQuery request, CancellationToken cancellationToken)
+    {
+        var order = await _orderRepository.GetByIdAsync(request.OrderId, cancellationToken);
+
+        if (order is null)
+        {
+            throw new OrderNotFoundException(request.OrderId);
+        }
+
+        return MapToResponse(order);
+    }
+
+    private static GetOrderResponse MapToResponse(Order order)
+    {
+        return new GetOrderResponse
+        {
+            OrderId = order.Id,
+            OrderNumber = order.OrderNumber,
+            CustomerId = order.CustomerId,
+            RestaurantId = order.RestaurantId,
+            Status = order.Status.ToString(),
+            LineItems = order.LineItems.Select(li => new GetOrderLineItemResponse
+            {
+                MenuItemId = li.MenuItemId,
+                MenuItemName = li.MenuItemName,
+                Quantity = li.Quantity,
+                UnitPrice = li.UnitPrice
+            }).ToList(),
+            DeliveryAddress = order.DeliveryAddress is not null
+                ? new GetOrderDeliveryAddressResponse
+                {
+                    Street = order.DeliveryAddress.Street,
+                    City = order.DeliveryAddress.City,
+                    Postcode = order.DeliveryAddress.Postcode,
+                    Latitude = order.DeliveryAddress.Latitude,
+                    Longitude = order.DeliveryAddress.Longitude
+                }
+                : null,
+            OrderTotal = order.OrderTotal is not null
+                ? new GetOrderTotalResponse
+                {
+                    Subtotal = order.OrderTotal.Subtotal,
+                    DeliveryFee = order.OrderTotal.DeliveryFee,
+                    Total = order.OrderTotal.Total
+                }
+                : null,
+            Timestamps = new GetOrderTimestampsResponse
+            {
+                CreatedAt = order.CreatedAt,
+                PlacedAt = order.PlacedAt,
+                AcceptedAt = order.AcceptedAt,
+                PreparingAt = order.PreparingAt,
+                ReadyForPickupAt = order.ReadyForPickupAt,
+                InDeliveryAt = order.InDeliveryAt,
+                DeliveredAt = order.DeliveredAt,
+                RejectedAt = order.RejectedAt,
+                CancelledAt = order.CancelledAt
+            }
+        };
+    }
+}

--- a/src/Orders/Domain/Queries/GetOrdersByCustomerQuery.cs
+++ b/src/Orders/Domain/Queries/GetOrdersByCustomerQuery.cs
@@ -1,0 +1,75 @@
+using MediatR;
+
+namespace Orders.Domain.Queries;
+
+/// <summary>
+/// Query to retrieve all orders for a customer, sorted by creation date descending.
+/// Supports pagination via continuation tokens.
+/// Dispatched from GetOrdersByCustomerFunction to the GetOrdersByCustomerQueryHandler via MediatR.
+/// This is a read-only operation -- no state changes or domain events are produced.
+/// </summary>
+public sealed record GetOrdersByCustomerQuery : IRequest<GetOrdersByCustomerResponse>
+{
+    /// <summary>
+    /// Identifier of the customer whose orders to retrieve.
+    /// </summary>
+    public required Guid CustomerId { get; init; }
+
+    /// <summary>
+    /// Optional continuation token for paginated results.
+    /// </summary>
+    public string? ContinuationToken { get; init; }
+}
+
+/// <summary>
+/// Response DTO containing a paginated list of order summaries for a customer.
+/// </summary>
+public sealed record GetOrdersByCustomerResponse
+{
+    /// <summary>
+    /// List of order summaries for the customer.
+    /// </summary>
+    public required List<OrderSummaryResponse> Orders { get; init; }
+
+    /// <summary>
+    /// Continuation token for the next page of results, or null if no more results.
+    /// </summary>
+    public string? ContinuationToken { get; init; }
+}
+
+/// <summary>
+/// Summary DTO for an individual order within the GetOrdersByCustomerResponse.
+/// Contains only the fields needed for a list view, not the full order details.
+/// </summary>
+public sealed record OrderSummaryResponse
+{
+    /// <summary>
+    /// Unique order identifier.
+    /// </summary>
+    public required Guid OrderId { get; init; }
+
+    /// <summary>
+    /// Human-readable order number (format: ORD-YYYYMMDD-sequential).
+    /// </summary>
+    public required string OrderNumber { get; init; }
+
+    /// <summary>
+    /// Name of the restaurant fulfilling the order.
+    /// </summary>
+    public required string RestaurantName { get; init; }
+
+    /// <summary>
+    /// Order total including delivery fee.
+    /// </summary>
+    public required decimal Total { get; init; }
+
+    /// <summary>
+    /// Current order status.
+    /// </summary>
+    public required string Status { get; init; }
+
+    /// <summary>
+    /// Timestamp when the order was created.
+    /// </summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+}

--- a/src/Orders/Domain/Queries/GetOrdersByCustomerQueryHandler.cs
+++ b/src/Orders/Domain/Queries/GetOrdersByCustomerQueryHandler.cs
@@ -1,0 +1,47 @@
+using MediatR;
+using Orders.Domain.Aggregates;
+using Orders.Infrastructure.Repositories;
+
+namespace Orders.Domain.Queries;
+
+/// <summary>
+/// Handles the GetOrdersByCustomerQuery by loading orders from the repository
+/// and mapping them to order summary DTOs. This is a pure read operation --
+/// no business logic, no state changes, no domain events.
+/// </summary>
+public sealed class GetOrdersByCustomerQueryHandler : IRequestHandler<GetOrdersByCustomerQuery, GetOrdersByCustomerResponse>
+{
+    private readonly IOrderRepository _orderRepository;
+
+    public GetOrdersByCustomerQueryHandler(IOrderRepository orderRepository)
+    {
+        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+    }
+
+    public async Task<GetOrdersByCustomerResponse> Handle(GetOrdersByCustomerQuery request, CancellationToken cancellationToken)
+    {
+        var (orders, continuationToken) = await _orderRepository.GetByCustomerIdAsync(
+            request.CustomerId,
+            request.ContinuationToken,
+            cancellationToken: cancellationToken);
+
+        return new GetOrdersByCustomerResponse
+        {
+            Orders = orders.Select(MapToSummary).ToList(),
+            ContinuationToken = continuationToken
+        };
+    }
+
+    private static OrderSummaryResponse MapToSummary(Order order)
+    {
+        return new OrderSummaryResponse
+        {
+            OrderId = order.Id,
+            OrderNumber = order.OrderNumber,
+            RestaurantName = string.Empty, // Restaurant name is not stored on the Order aggregate
+            Total = order.OrderTotal?.Total ?? 0m,
+            Status = order.Status.ToString(),
+            CreatedAt = order.CreatedAt
+        };
+    }
+}

--- a/src/Orders/Domain/ValueObjects/OrderStatus.cs
+++ b/src/Orders/Domain/ValueObjects/OrderStatus.cs
@@ -1,0 +1,18 @@
+namespace Orders.Domain.ValueObjects;
+
+/// <summary>
+/// Enumeration of all possible states in the Order aggregate lifecycle.
+/// See FDD section 3.2 for the full state machine definition.
+/// </summary>
+public enum OrderStatus
+{
+    Draft = 0,
+    Placed = 1,
+    Accepted = 2,
+    Preparing = 3,
+    ReadyForPickup = 4,
+    InDelivery = 5,
+    Delivered = 6,
+    Rejected = 7,
+    Cancelled = 8
+}

--- a/src/Orders/Functions/CancelOrderFunction.cs
+++ b/src/Orders/Functions/CancelOrderFunction.cs
@@ -1,0 +1,88 @@
+using System.Net;
+using MediatR;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Orders.Domain.Commands;
+using Orders.Domain.Exceptions;
+using Orders.Functions.Models;
+
+namespace Orders.Functions;
+
+/// <summary>
+/// Azure Function HTTP endpoint for cancelling an order.
+/// POST /orders/{orderId}/cancel
+/// Isolated worker model. Delegates all business logic to MediatR pipeline.
+/// </summary>
+public sealed class CancelOrderFunction
+{
+    private readonly IMediator _mediator;
+    private readonly ILogger<CancelOrderFunction> _logger;
+
+    public CancelOrderFunction(IMediator mediator, ILogger<CancelOrderFunction> logger)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [Function("CancelOrder")]
+    public async Task<HttpResponseData> Run(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "orders/{orderId}/cancel")]
+        HttpRequestData request,
+        string orderId)
+    {
+        _logger.LogInformation("Cancel order request received for orderId: {OrderId}", orderId);
+
+        // --- Parse and validate the route parameter ---
+        if (!Guid.TryParse(orderId, out var parsedOrderId))
+        {
+            _logger.LogWarning("Invalid orderId format: {OrderId}", orderId);
+            return await CreateErrorResponse(request, HttpStatusCode.BadRequest, "INVALID_ORDER_ID",
+                "The orderId must be a valid GUID.");
+        }
+
+        try
+        {
+            // --- Dispatch the command via MediatR ---
+            var command = new CancelOrderCommand { OrderId = parsedOrderId };
+            var result = await _mediator.Send(command);
+
+            // --- Return 200 with the updated order ---
+            var response = request.CreateResponse(HttpStatusCode.OK);
+            await response.WriteAsJsonAsync(result);
+            return response;
+        }
+        catch (OrderNotFoundException ex)
+        {
+            _logger.LogWarning(ex, "Order not found: {OrderId}", parsedOrderId);
+            return await CreateErrorResponse(request, HttpStatusCode.NotFound, ex.ErrorCode, ex.Message);
+        }
+        catch (OrderCannotBeCancelledException ex)
+        {
+            _logger.LogWarning(ex, "Order cannot be cancelled: {OrderId}, current status: {Status}",
+                parsedOrderId, ex.CurrentStatus);
+            return await CreateErrorResponse(request, HttpStatusCode.Conflict, ex.ErrorCode, ex.Message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error cancelling order: {OrderId}", parsedOrderId);
+            return await CreateErrorResponse(request, HttpStatusCode.InternalServerError, "INTERNAL_ERROR",
+                "An unexpected error occurred.");
+        }
+    }
+
+    private static async Task<HttpResponseData> CreateErrorResponse(
+        HttpRequestData request,
+        HttpStatusCode statusCode,
+        string errorCode,
+        string message)
+    {
+        var response = request.CreateResponse(statusCode);
+        await response.WriteAsJsonAsync(new ErrorResponse
+        {
+            ErrorCode = errorCode,
+            Message = message
+        });
+        return response;
+    }
+}

--- a/src/Orders/Functions/EventHandlers/HandleDeliveryCompletedFunction.cs
+++ b/src/Orders/Functions/EventHandlers/HandleDeliveryCompletedFunction.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using Orders.Domain.Events.Consumed;
+using Orders.Domain.Exceptions;
+using Orders.Infrastructure.Repositories;
+
+namespace Orders.Functions.EventHandlers;
+
+/// <summary>
+/// Azure Function Service Bus trigger for handling DeliveryCompleted events
+/// from the Delivery context. Transitions the order status from InDelivery to Delivered.
+/// This is the terminal happy-path transition for an order.
+/// Invalid transitions are logged as warnings and the message is completed to prevent
+/// poison message scenarios.
+/// </summary>
+public sealed class HandleDeliveryCompletedFunction
+{
+    private readonly IOrderRepository _orderRepository;
+    private readonly ILogger<HandleDeliveryCompletedFunction> _logger;
+
+    public HandleDeliveryCompletedFunction(IOrderRepository orderRepository, ILogger<HandleDeliveryCompletedFunction> logger)
+    {
+        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [Function("HandleDeliveryCompleted")]
+    public async Task Run(
+        [ServiceBusTrigger("delivery.completed", "orders-context", Connection = "ServiceBusConnection")]
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions messageActions)
+    {
+        _logger.LogInformation("HandleDeliveryCompleted: Processing message {MessageId}.", message.MessageId);
+
+        // 1. Deserialize the event from message body
+        var deliveryCompletedEvent = JsonSerializer.Deserialize<DeliveryCompletedEvent>(
+            message.Body.ToString(),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        if (deliveryCompletedEvent?.Payload is null)
+        {
+            _logger.LogWarning("HandleDeliveryCompleted: Failed to deserialize message {MessageId}. Completing to avoid poison message.", message.MessageId);
+            await messageActions.CompleteMessageAsync(message);
+            return;
+        }
+
+        var orderId = deliveryCompletedEvent.Payload.OrderId;
+        _logger.LogInformation("HandleDeliveryCompleted: Processing DeliveryCompleted for orderId {OrderId}, eventId {EventId}, slaBreached {SlaBreached}.",
+            orderId, deliveryCompletedEvent.EventId, deliveryCompletedEvent.Payload.SlaBreached);
+
+        // 2. Load the Order aggregate from repository
+        var order = await _orderRepository.GetByIdAsync(orderId);
+
+        if (order is null)
+        {
+            _logger.LogWarning("HandleDeliveryCompleted: Order {OrderId} not found. Completing message to avoid poison message.", orderId);
+            await messageActions.CompleteMessageAsync(message);
+            return;
+        }
+
+        // 3. Call the appropriate state transition method on the aggregate
+        try
+        {
+            order.MarkDelivered();
+        }
+        catch (InvalidOrderTransitionException ex)
+        {
+            _logger.LogWarning(ex,
+                "HandleDeliveryCompleted: Invalid transition for order {OrderId}. Current status: {CurrentStatus}. Discarding event.",
+                orderId, ex.CurrentStatus);
+            await messageActions.CompleteMessageAsync(message);
+            return;
+        }
+
+        // 4. Save via repository (outbox pattern handles any raised events)
+        await _orderRepository.SaveAsync(order);
+
+        // 5. Complete the message
+        await messageActions.CompleteMessageAsync(message);
+
+        _logger.LogInformation("HandleDeliveryCompleted: Successfully transitioned order {OrderId} to Delivered.", orderId);
+    }
+}

--- a/src/Orders/Functions/EventHandlers/HandleDriverAssignedFunction.cs
+++ b/src/Orders/Functions/EventHandlers/HandleDriverAssignedFunction.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using Orders.Domain.Events.Consumed;
+using Orders.Domain.Exceptions;
+using Orders.Infrastructure.Repositories;
+
+namespace Orders.Functions.EventHandlers;
+
+/// <summary>
+/// Azure Function Service Bus trigger for handling DriverAssigned events
+/// from the Delivery context. Transitions the order status from ReadyForPickup to InDelivery.
+/// Invalid transitions are logged as warnings and the message is completed to prevent
+/// poison message scenarios.
+/// </summary>
+public sealed class HandleDriverAssignedFunction
+{
+    private readonly IOrderRepository _orderRepository;
+    private readonly ILogger<HandleDriverAssignedFunction> _logger;
+
+    public HandleDriverAssignedFunction(IOrderRepository orderRepository, ILogger<HandleDriverAssignedFunction> logger)
+    {
+        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [Function("HandleDriverAssigned")]
+    public async Task Run(
+        [ServiceBusTrigger("delivery.driver-assigned", "orders-context", Connection = "ServiceBusConnection")]
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions messageActions)
+    {
+        _logger.LogInformation("HandleDriverAssigned: Processing message {MessageId}.", message.MessageId);
+
+        // 1. Deserialize the event from message body
+        var driverAssignedEvent = JsonSerializer.Deserialize<DriverAssignedEvent>(
+            message.Body.ToString(),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        if (driverAssignedEvent?.Payload is null)
+        {
+            _logger.LogWarning("HandleDriverAssigned: Failed to deserialize message {MessageId}. Completing to avoid poison message.", message.MessageId);
+            await messageActions.CompleteMessageAsync(message);
+            return;
+        }
+
+        var orderId = driverAssignedEvent.Payload.OrderId;
+        _logger.LogInformation("HandleDriverAssigned: Processing DriverAssigned for orderId {OrderId}, driverId {DriverId}, eventId {EventId}.",
+            orderId, driverAssignedEvent.Payload.DriverId, driverAssignedEvent.EventId);
+
+        // 2. Load the Order aggregate from repository
+        var order = await _orderRepository.GetByIdAsync(orderId);
+
+        if (order is null)
+        {
+            _logger.LogWarning("HandleDriverAssigned: Order {OrderId} not found. Completing message to avoid poison message.", orderId);
+            await messageActions.CompleteMessageAsync(message);
+            return;
+        }
+
+        // 3. Call the appropriate state transition method on the aggregate
+        try
+        {
+            order.MarkInDelivery();
+        }
+        catch (InvalidOrderTransitionException ex)
+        {
+            _logger.LogWarning(ex,
+                "HandleDriverAssigned: Invalid transition for order {OrderId}. Current status: {CurrentStatus}. Discarding event.",
+                orderId, ex.CurrentStatus);
+            await messageActions.CompleteMessageAsync(message);
+            return;
+        }
+
+        // 4. Save via repository (outbox pattern handles any raised events)
+        await _orderRepository.SaveAsync(order);
+
+        // 5. Complete the message
+        await messageActions.CompleteMessageAsync(message);
+
+        _logger.LogInformation("HandleDriverAssigned: Successfully transitioned order {OrderId} to InDelivery.", orderId);
+    }
+}

--- a/src/Orders/Functions/EventHandlers/HandleOrderAcceptedFunction.cs
+++ b/src/Orders/Functions/EventHandlers/HandleOrderAcceptedFunction.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using Orders.Domain.Events.Consumed;
+using Orders.Domain.Exceptions;
+using Orders.Infrastructure.Repositories;
+
+namespace Orders.Functions.EventHandlers;
+
+/// <summary>
+/// Azure Function Service Bus trigger for handling OrderAccepted events
+/// from the Restaurant context. Transitions the order status from Placed to Accepted.
+/// Invalid transitions are logged as warnings and the message is completed to prevent
+/// poison message scenarios.
+/// </summary>
+public sealed class HandleOrderAcceptedFunction
+{
+    private readonly IOrderRepository _orderRepository;
+    private readonly ILogger<HandleOrderAcceptedFunction> _logger;
+
+    public HandleOrderAcceptedFunction(IOrderRepository orderRepository, ILogger<HandleOrderAcceptedFunction> logger)
+    {
+        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [Function("HandleOrderAccepted")]
+    public async Task Run(
+        [ServiceBusTrigger("restaurant.order-accepted", "orders-context", Connection = "ServiceBusConnection")]
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions messageActions)
+    {
+        _logger.LogInformation("HandleOrderAccepted: Processing message {MessageId}.", message.MessageId);
+
+        // 1. Deserialize the event from message body
+        var orderAcceptedEvent = JsonSerializer.Deserialize<OrderAcceptedEvent>(
+            message.Body.ToString(),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        if (orderAcceptedEvent?.Payload is null)
+        {
+            _logger.LogWarning("HandleOrderAccepted: Failed to deserialize message {MessageId}. Completing to avoid poison message.", message.MessageId);
+            await messageActions.CompleteMessageAsync(message);
+            return;
+        }
+
+        var orderId = orderAcceptedEvent.Payload.OrderId;
+        _logger.LogInformation("HandleOrderAccepted: Processing OrderAccepted for orderId {OrderId}, eventId {EventId}.",
+            orderId, orderAcceptedEvent.EventId);
+
+        // 2. Load the Order aggregate from repository
+        var order = await _orderRepository.GetByIdAsync(orderId);
+
+        if (order is null)
+        {
+            _logger.LogWarning("HandleOrderAccepted: Order {OrderId} not found. Completing message to avoid poison message.", orderId);
+            await messageActions.CompleteMessageAsync(message);
+            return;
+        }
+
+        // 3. Call the appropriate state transition method on the aggregate
+        try
+        {
+            order.Accept();
+        }
+        catch (InvalidOrderTransitionException ex)
+        {
+            _logger.LogWarning(ex,
+                "HandleOrderAccepted: Invalid transition for order {OrderId}. Current status: {CurrentStatus}. Discarding event.",
+                orderId, ex.CurrentStatus);
+            await messageActions.CompleteMessageAsync(message);
+            return;
+        }
+
+        // 4. Save via repository (outbox pattern handles any raised events)
+        await _orderRepository.SaveAsync(order);
+
+        // 5. Complete the message
+        await messageActions.CompleteMessageAsync(message);
+
+        _logger.LogInformation("HandleOrderAccepted: Successfully transitioned order {OrderId} to Accepted.", orderId);
+    }
+}

--- a/src/Orders/Functions/EventHandlers/HandleOrderReadyForPickupFunction.cs
+++ b/src/Orders/Functions/EventHandlers/HandleOrderReadyForPickupFunction.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using Orders.Domain.Events.Consumed;
+using Orders.Domain.Exceptions;
+using Orders.Infrastructure.Repositories;
+
+namespace Orders.Functions.EventHandlers;
+
+/// <summary>
+/// Azure Function Service Bus trigger for handling OrderReadyForPickup events
+/// from the Restaurant context. Transitions the order status to ReadyForPickup.
+/// Accepts transitions from both Accepted and Preparing statuses since the Order context
+/// may not have received an intermediate Preparing status update.
+/// Invalid transitions are logged as warnings and the message is completed.
+/// </summary>
+public sealed class HandleOrderReadyForPickupFunction
+{
+    private readonly IOrderRepository _orderRepository;
+    private readonly ILogger<HandleOrderReadyForPickupFunction> _logger;
+
+    public HandleOrderReadyForPickupFunction(IOrderRepository orderRepository, ILogger<HandleOrderReadyForPickupFunction> logger)
+    {
+        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [Function("HandleOrderReady")]
+    public async Task Run(
+        [ServiceBusTrigger("restaurant.order-ready", "orders-context", Connection = "ServiceBusConnection")]
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions messageActions)
+    {
+        _logger.LogInformation("HandleOrderReady: Processing message {MessageId}.", message.MessageId);
+
+        // 1. Deserialize the event from message body
+        var readyEvent = JsonSerializer.Deserialize<OrderReadyForPickupEvent>(
+            message.Body.ToString(),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        if (readyEvent?.Payload is null)
+        {
+            _logger.LogWarning("HandleOrderReady: Failed to deserialize message {MessageId}. Completing to avoid poison message.", message.MessageId);
+            await messageActions.CompleteMessageAsync(message);
+            return;
+        }
+
+        var orderId = readyEvent.Payload.OrderId;
+        _logger.LogInformation("HandleOrderReady: Processing OrderReadyForPickup for orderId {OrderId}, eventId {EventId}.",
+            orderId, readyEvent.EventId);
+
+        // 2. Load the Order aggregate from repository
+        var order = await _orderRepository.GetByIdAsync(orderId);
+
+        if (order is null)
+        {
+            _logger.LogWarning("HandleOrderReady: Order {OrderId} not found. Completing message to avoid poison message.", orderId);
+            await messageActions.CompleteMessageAsync(message);
+            return;
+        }
+
+        // 3. Call the appropriate state transition method on the aggregate
+        try
+        {
+            order.MarkReadyForPickup();
+        }
+        catch (InvalidOrderTransitionException ex)
+        {
+            _logger.LogWarning(ex,
+                "HandleOrderReady: Invalid transition for order {OrderId}. Current status: {CurrentStatus}. Discarding event.",
+                orderId, ex.CurrentStatus);
+            await messageActions.CompleteMessageAsync(message);
+            return;
+        }
+
+        // 4. Save via repository (outbox pattern handles any raised events)
+        await _orderRepository.SaveAsync(order);
+
+        // 5. Complete the message
+        await messageActions.CompleteMessageAsync(message);
+
+        _logger.LogInformation("HandleOrderReady: Successfully transitioned order {OrderId} to ReadyForPickup.", orderId);
+    }
+}

--- a/src/Orders/Functions/EventHandlers/HandleOrderRejectedFunction.cs
+++ b/src/Orders/Functions/EventHandlers/HandleOrderRejectedFunction.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using Orders.Domain.Events.Consumed;
+using Orders.Domain.Exceptions;
+using Orders.Infrastructure.Repositories;
+
+namespace Orders.Functions.EventHandlers;
+
+/// <summary>
+/// Azure Function Service Bus trigger for handling OrderRejected events
+/// from the Restaurant context. Transitions the order status from Placed to Rejected.
+/// Invalid transitions are logged as warnings and the message is completed to prevent
+/// poison message scenarios.
+/// </summary>
+public sealed class HandleOrderRejectedFunction
+{
+    private readonly IOrderRepository _orderRepository;
+    private readonly ILogger<HandleOrderRejectedFunction> _logger;
+
+    public HandleOrderRejectedFunction(IOrderRepository orderRepository, ILogger<HandleOrderRejectedFunction> logger)
+    {
+        _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [Function("HandleOrderRejected")]
+    public async Task Run(
+        [ServiceBusTrigger("restaurant.order-rejected", "orders-context", Connection = "ServiceBusConnection")]
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions messageActions)
+    {
+        _logger.LogInformation("HandleOrderRejected: Processing message {MessageId}.", message.MessageId);
+
+        // 1. Deserialize the event from message body
+        var orderRejectedEvent = JsonSerializer.Deserialize<OrderRejectedEvent>(
+            message.Body.ToString(),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        if (orderRejectedEvent?.Payload is null)
+        {
+            _logger.LogWarning("HandleOrderRejected: Failed to deserialize message {MessageId}. Completing to avoid poison message.", message.MessageId);
+            await messageActions.CompleteMessageAsync(message);
+            return;
+        }
+
+        var orderId = orderRejectedEvent.Payload.OrderId;
+        _logger.LogInformation("HandleOrderRejected: Processing OrderRejected for orderId {OrderId}, eventId {EventId}, reason {ReasonCode}.",
+            orderId, orderRejectedEvent.EventId, orderRejectedEvent.Payload.ReasonCode);
+
+        // 2. Load the Order aggregate from repository
+        var order = await _orderRepository.GetByIdAsync(orderId);
+
+        if (order is null)
+        {
+            _logger.LogWarning("HandleOrderRejected: Order {OrderId} not found. Completing message to avoid poison message.", orderId);
+            await messageActions.CompleteMessageAsync(message);
+            return;
+        }
+
+        // 3. Call the appropriate state transition method on the aggregate
+        try
+        {
+            order.Reject(orderRejectedEvent.Payload.ReasonCode);
+        }
+        catch (InvalidOrderTransitionException ex)
+        {
+            _logger.LogWarning(ex,
+                "HandleOrderRejected: Invalid transition for order {OrderId}. Current status: {CurrentStatus}. Discarding event.",
+                orderId, ex.CurrentStatus);
+            await messageActions.CompleteMessageAsync(message);
+            return;
+        }
+
+        // 4. Save via repository (outbox pattern handles any raised events)
+        await _orderRepository.SaveAsync(order);
+
+        // 5. Complete the message
+        await messageActions.CompleteMessageAsync(message);
+
+        _logger.LogInformation("HandleOrderRejected: Successfully transitioned order {OrderId} to Rejected.", orderId);
+    }
+}

--- a/src/Orders/Functions/GetOrderFunction.cs
+++ b/src/Orders/Functions/GetOrderFunction.cs
@@ -1,0 +1,82 @@
+using System.Net;
+using MediatR;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Orders.Domain.Exceptions;
+using Orders.Domain.Queries;
+using Orders.Functions.Models;
+
+namespace Orders.Functions;
+
+/// <summary>
+/// Azure Function HTTP endpoint for retrieving a single order by ID.
+/// GET /orders/{orderId}
+/// Isolated worker model. Delegates to MediatR query pipeline.
+/// </summary>
+public sealed class GetOrderFunction
+{
+    private readonly IMediator _mediator;
+    private readonly ILogger<GetOrderFunction> _logger;
+
+    public GetOrderFunction(IMediator mediator, ILogger<GetOrderFunction> logger)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [Function("GetOrder")]
+    public async Task<HttpResponseData> Run(
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "orders/{orderId}")]
+        HttpRequestData request,
+        string orderId)
+    {
+        _logger.LogInformation("Get order request received for orderId: {OrderId}", orderId);
+
+        // --- Parse and validate the route parameter ---
+        if (!Guid.TryParse(orderId, out var parsedOrderId))
+        {
+            _logger.LogWarning("Invalid orderId format: {OrderId}", orderId);
+            return await CreateErrorResponse(request, HttpStatusCode.BadRequest, "INVALID_ORDER_ID",
+                "The orderId must be a valid GUID.");
+        }
+
+        try
+        {
+            // --- Dispatch the query via MediatR ---
+            var query = new GetOrderQuery { OrderId = parsedOrderId };
+            var result = await _mediator.Send(query);
+
+            // --- Return 200 with the full order ---
+            var response = request.CreateResponse(HttpStatusCode.OK);
+            await response.WriteAsJsonAsync(result);
+            return response;
+        }
+        catch (OrderNotFoundException ex)
+        {
+            _logger.LogWarning(ex, "Order not found: {OrderId}", parsedOrderId);
+            return await CreateErrorResponse(request, HttpStatusCode.NotFound, ex.ErrorCode, ex.Message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error retrieving order: {OrderId}", parsedOrderId);
+            return await CreateErrorResponse(request, HttpStatusCode.InternalServerError, "INTERNAL_ERROR",
+                "An unexpected error occurred.");
+        }
+    }
+
+    private static async Task<HttpResponseData> CreateErrorResponse(
+        HttpRequestData request,
+        HttpStatusCode statusCode,
+        string errorCode,
+        string message)
+    {
+        var response = request.CreateResponse(statusCode);
+        await response.WriteAsJsonAsync(new ErrorResponse
+        {
+            ErrorCode = errorCode,
+            Message = message
+        });
+        return response;
+    }
+}

--- a/src/Orders/Functions/GetOrdersByCustomerFunction.cs
+++ b/src/Orders/Functions/GetOrdersByCustomerFunction.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using MediatR;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Orders.Domain.Queries;
+using Orders.Functions.Models;
+
+namespace Orders.Functions;
+
+/// <summary>
+/// Azure Function HTTP endpoint for retrieving all orders for a customer.
+/// GET /orders?customerId={customerId}&amp;continuationToken={continuationToken}
+/// Isolated worker model. Delegates to MediatR query pipeline.
+/// </summary>
+public sealed class GetOrdersByCustomerFunction
+{
+    private readonly IMediator _mediator;
+    private readonly ILogger<GetOrdersByCustomerFunction> _logger;
+
+    public GetOrdersByCustomerFunction(IMediator mediator, ILogger<GetOrdersByCustomerFunction> logger)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [Function("GetOrdersByCustomer")]
+    public async Task<HttpResponseData> Run(
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "orders")]
+        HttpRequestData request)
+    {
+        _logger.LogInformation("Get orders by customer request received.");
+
+        // --- Parse and validate query parameters ---
+        var queryParams = System.Web.HttpUtility.ParseQueryString(request.Url.Query);
+        var customerIdParam = queryParams["customerId"];
+
+        if (string.IsNullOrWhiteSpace(customerIdParam) || !Guid.TryParse(customerIdParam, out var customerId) || customerId == Guid.Empty)
+        {
+            _logger.LogWarning("Invalid or missing customerId query parameter: {CustomerId}", customerIdParam);
+            return await CreateErrorResponse(request, HttpStatusCode.BadRequest, "ORDER_INVALID_CUSTOMER",
+                "The customerId query parameter must be a valid, non-empty GUID.");
+        }
+
+        var continuationToken = queryParams["continuationToken"];
+
+        try
+        {
+            // --- Dispatch the query via MediatR ---
+            var query = new GetOrdersByCustomerQuery
+            {
+                CustomerId = customerId,
+                ContinuationToken = continuationToken
+            };
+            var result = await _mediator.Send(query);
+
+            // --- Return 200 with the paginated order summaries ---
+            var response = request.CreateResponse(HttpStatusCode.OK);
+            await response.WriteAsJsonAsync(result);
+            return response;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error retrieving orders for customer: {CustomerId}", customerId);
+            return await CreateErrorResponse(request, HttpStatusCode.InternalServerError, "INTERNAL_ERROR",
+                "An unexpected error occurred.");
+        }
+    }
+
+    private static async Task<HttpResponseData> CreateErrorResponse(
+        HttpRequestData request,
+        HttpStatusCode statusCode,
+        string errorCode,
+        string message)
+    {
+        var response = request.CreateResponse(statusCode);
+        await response.WriteAsJsonAsync(new ErrorResponse
+        {
+            ErrorCode = errorCode,
+            Message = message
+        });
+        return response;
+    }
+}

--- a/src/Orders/Functions/Models/ErrorResponse.cs
+++ b/src/Orders/Functions/Models/ErrorResponse.cs
@@ -1,0 +1,10 @@
+namespace Orders.Functions.Models;
+
+/// <summary>
+/// Standard error response DTO for API error payloads.
+/// </summary>
+internal sealed class ErrorResponse
+{
+    public string ErrorCode { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+}

--- a/src/Orders/Functions/PlaceOrderFunction.cs
+++ b/src/Orders/Functions/PlaceOrderFunction.cs
@@ -1,0 +1,82 @@
+using System.Net;
+using MediatR;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Orders.Domain.Commands;
+using Orders.Domain.Exceptions;
+using Orders.Functions.Models;
+
+namespace Orders.Functions;
+
+/// <summary>
+/// Azure Function HTTP endpoint for placing a new order.
+/// POST /orders
+/// Isolated worker model. Validates request body and delegates business logic to MediatR pipeline.
+/// </summary>
+public sealed class PlaceOrderFunction
+{
+    private readonly IMediator _mediator;
+    private readonly ILogger<PlaceOrderFunction> _logger;
+
+    public PlaceOrderFunction(IMediator mediator, ILogger<PlaceOrderFunction> logger)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [Function("PlaceOrder")]
+    public async Task<HttpResponseData> Run(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "orders")]
+        HttpRequestData request)
+    {
+        _logger.LogInformation("Place order request received.");
+
+        try
+        {
+            // --- Deserialize the request body ---
+            var command = await request.ReadFromJsonAsync<PlaceOrderCommand>();
+
+            if (command is null)
+            {
+                _logger.LogWarning("Request body is null or could not be deserialized.");
+                return await CreateErrorResponse(request, HttpStatusCode.BadRequest, "INVALID_REQUEST",
+                    "Request body is required and must be valid JSON.");
+            }
+
+            // --- Dispatch the command via MediatR ---
+            var result = await _mediator.Send(command);
+
+            // --- Return 201 Created with the order details ---
+            var response = request.CreateResponse(HttpStatusCode.Created);
+            await response.WriteAsJsonAsync(result);
+            return response;
+        }
+        catch (InvalidOrderException ex)
+        {
+            _logger.LogWarning(ex, "Order validation failed: {ErrorCode} - {Message}", ex.ErrorCode, ex.Message);
+            return await CreateErrorResponse(request, HttpStatusCode.BadRequest, ex.ErrorCode, ex.Message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error placing order.");
+            return await CreateErrorResponse(request, HttpStatusCode.InternalServerError, "INTERNAL_ERROR",
+                "An unexpected error occurred.");
+        }
+    }
+
+    private static async Task<HttpResponseData> CreateErrorResponse(
+        HttpRequestData request,
+        HttpStatusCode statusCode,
+        string errorCode,
+        string message)
+    {
+        var response = request.CreateResponse(statusCode);
+        await response.WriteAsJsonAsync(new ErrorResponse
+        {
+            ErrorCode = errorCode,
+            Message = message
+        });
+        return response;
+    }
+}

--- a/src/Orders/Infrastructure/Models/OutboxMessage.cs
+++ b/src/Orders/Infrastructure/Models/OutboxMessage.cs
@@ -1,0 +1,20 @@
+namespace Orders.Infrastructure.Models;
+
+/// <summary>
+/// Represents an outbox message stored alongside the aggregate for reliable event publishing.
+/// TTL is 7 days. A background processor reads unprocessed messages and publishes to Service Bus.
+/// </summary>
+internal sealed class OutboxMessage
+{
+    public string Id { get; set; } = string.Empty;
+    public string PartitionKey { get; set; } = string.Empty;
+    public string EventType { get; set; } = string.Empty;
+    public string Payload { get; set; } = string.Empty;
+    public DateTimeOffset CreatedAt { get; set; }
+    public bool Processed { get; set; }
+
+    /// <summary>
+    /// Cosmos DB TTL in seconds. 7 days = 604800 seconds.
+    /// </summary>
+    public int Ttl { get; set; } = 604800;
+}

--- a/src/Orders/Infrastructure/Repositories/CosmosOrderRepository.cs
+++ b/src/Orders/Infrastructure/Repositories/CosmosOrderRepository.cs
@@ -1,0 +1,134 @@
+using System.Net;
+using Microsoft.Azure.Cosmos;
+using Orders.Domain.Aggregates;
+using Orders.Infrastructure.Models;
+
+namespace Orders.Infrastructure.Repositories;
+
+/// <summary>
+/// Cosmos DB implementation of IOrderRepository.
+/// Uses the orders container with customerId as partition key.
+/// Persists domain events to the outbox within the same transactional batch.
+/// </summary>
+public sealed class CosmosOrderRepository : IOrderRepository
+{
+    private readonly Container _ordersContainer;
+    private readonly Container _outboxContainer;
+
+    public CosmosOrderRepository(CosmosClient cosmosClient, string databaseName)
+    {
+        ArgumentNullException.ThrowIfNull(cosmosClient);
+        ArgumentException.ThrowIfNullOrWhiteSpace(databaseName);
+
+        var database = cosmosClient.GetDatabase(databaseName);
+        _ordersContainer = database.GetContainer("orders");
+        _outboxContainer = database.GetContainer("orders-outbox");
+    }
+
+    /// <inheritdoc />
+    public async Task<Order?> GetByIdAsync(Guid orderId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // Cross-partition query since we may not know the customerId at lookup time.
+            // For production, consider a secondary index or passing customerId as a parameter.
+            var query = new QueryDefinition("SELECT * FROM c WHERE c.id = @orderId")
+                .WithParameter("@orderId", orderId.ToString());
+
+            var iterator = _ordersContainer.GetItemQueryIterator<Order>(query);
+
+            while (iterator.HasMoreResults)
+            {
+                var response = await iterator.ReadNextAsync(cancellationToken);
+                var order = response.FirstOrDefault();
+                if (order is not null)
+                {
+                    order.ETag = response.ETag;
+                    return order;
+                }
+            }
+
+            return null;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<(List<Order> Orders, string? ContinuationToken)> GetByCustomerIdAsync(
+        Guid customerId,
+        string? continuationToken = null,
+        int pageSize = 20,
+        CancellationToken cancellationToken = default)
+    {
+        var query = new QueryDefinition("SELECT * FROM c WHERE c.CustomerId = @customerId ORDER BY c.CreatedAt DESC")
+            .WithParameter("@customerId", customerId.ToString());
+
+        var requestOptions = new QueryRequestOptions
+        {
+            PartitionKey = new PartitionKey(customerId.ToString()),
+            MaxItemCount = pageSize
+        };
+
+        var iterator = _ordersContainer.GetItemQueryIterator<Order>(
+            query,
+            continuationToken: continuationToken,
+            requestOptions: requestOptions);
+
+        var orders = new List<Order>();
+        string? nextContinuationToken = null;
+
+        if (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(cancellationToken);
+            orders.AddRange(response);
+            nextContinuationToken = response.ContinuationToken;
+        }
+
+        return (orders, nextContinuationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task SaveAsync(Order order, CancellationToken cancellationToken = default)
+    {
+        var partitionKey = new PartitionKey(order.CustomerId.ToString());
+
+        // Use a transactional batch to atomically persist the order and any outbox messages.
+        var batch = _ordersContainer.CreateTransactionalBatch(partitionKey);
+
+        // Upsert the order document
+        batch.UpsertItem(order, new TransactionalBatchItemRequestOptions
+        {
+            IfMatchEtag = order.ETag
+        });
+
+        // Persist each domain event as an outbox message in the same partition
+        foreach (var domainEvent in order.DomainEvents)
+        {
+            var outboxMessage = new OutboxMessage
+            {
+                Id = Guid.NewGuid().ToString(),
+                PartitionKey = order.CustomerId.ToString(),
+                EventType = domainEvent.GetType().Name,
+                Payload = System.Text.Json.JsonSerializer.Serialize(domainEvent, domainEvent.GetType()),
+                CreatedAt = DateTimeOffset.UtcNow,
+                Processed = false
+            };
+
+            batch.CreateItem(outboxMessage);
+        }
+
+        var batchResponse = await batch.ExecuteAsync(cancellationToken);
+
+        if (!batchResponse.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(
+                $"Failed to save order '{order.Id}'. Cosmos DB transactional batch returned status code {batchResponse.StatusCode}.");
+        }
+
+        // Clear domain events after successful persistence
+        order.ClearDomainEvents();
+    }
+}

--- a/src/Orders/Infrastructure/Repositories/IOrderRepository.cs
+++ b/src/Orders/Infrastructure/Repositories/IOrderRepository.cs
@@ -1,0 +1,44 @@
+using Orders.Domain.Aggregates;
+
+namespace Orders.Infrastructure.Repositories;
+
+/// <summary>
+/// Repository interface for the Order aggregate.
+/// Defined in Infrastructure (not Domain) because the handler references it,
+/// but the domain layer itself has zero infrastructure dependencies.
+/// </summary>
+public interface IOrderRepository
+{
+    /// <summary>
+    /// Loads an Order aggregate by its unique identifier.
+    /// Returns null if no order with the given ID exists.
+    /// </summary>
+    /// <param name="orderId">The unique order identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The Order aggregate, or null if not found.</returns>
+    Task<Order?> GetByIdAsync(Guid orderId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Loads all Order aggregates for a given customer, sorted by creation date descending.
+    /// Supports pagination via Cosmos DB continuation tokens.
+    /// </summary>
+    /// <param name="customerId">The customer identifier (Cosmos DB partition key).</param>
+    /// <param name="continuationToken">Optional continuation token for pagination.</param>
+    /// <param name="pageSize">Maximum number of orders to return per page. Default is 20.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A tuple containing the list of orders and an optional continuation token for the next page.</returns>
+    Task<(List<Order> Orders, string? ContinuationToken)> GetByCustomerIdAsync(
+        Guid customerId,
+        string? continuationToken = null,
+        int pageSize = 20,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Persists the Order aggregate. Handles both insert and update via upsert.
+    /// Also persists any uncommitted domain events to the outbox within the same
+    /// Cosmos DB transactional batch for reliable event publishing.
+    /// </summary>
+    /// <param name="order">The Order aggregate to persist.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task SaveAsync(Order order, CancellationToken cancellationToken = default);
+}

--- a/tests/Orders.Tests/Unit/ORD001Tests.cs
+++ b/tests/Orders.Tests/Unit/ORD001Tests.cs
@@ -1,0 +1,454 @@
+using FluentAssertions;
+using Moq;
+using Orders.Domain.Aggregates;
+using Orders.Domain.Commands;
+using Orders.Domain.Events;
+using Orders.Domain.Exceptions;
+using Orders.Domain.ValueObjects;
+using Orders.Infrastructure.Repositories;
+using Xunit;
+
+namespace Orders.Tests.Unit;
+
+/// <summary>
+/// Unit tests for ORD-001: Place Order.
+/// Tests business rule validation (ORD-R01 through ORD-R04), order total calculation (ORD-R06),
+/// OrderPlaced domain event raising, and handler orchestration.
+/// </summary>
+public class ORD001Tests
+{
+    #region Test Helpers
+
+    private static PlaceOrderCommand CreateValidCommand(
+        Guid? customerId = null,
+        Guid? restaurantId = null,
+        List<PlaceOrderLineItem>? lineItems = null,
+        PlaceOrderDeliveryAddress? deliveryAddress = null)
+    {
+        return new PlaceOrderCommand
+        {
+            CustomerId = customerId ?? Guid.NewGuid(),
+            RestaurantId = restaurantId ?? Guid.NewGuid(),
+            DeliveryAddress = deliveryAddress ?? new PlaceOrderDeliveryAddress
+            {
+                Street = "123 High Street",
+                City = "London",
+                Postcode = "SW1A 1AA",
+                Latitude = 51.5074,
+                Longitude = -0.1278
+            },
+            LineItems = lineItems ?? new List<PlaceOrderLineItem>
+            {
+                new()
+                {
+                    MenuItemId = Guid.NewGuid(),
+                    MenuItemName = "Margherita Pizza",
+                    Quantity = 2,
+                    UnitPrice = 8.99m
+                }
+            }
+        };
+    }
+
+    private static (PlaceOrderCommandHandler handler, Mock<IOrderRepository> repo) CreateHandler()
+    {
+        var mockRepo = new Mock<IOrderRepository>();
+        mockRepo.Setup(r => r.SaveAsync(It.IsAny<Order>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var handler = new PlaceOrderCommandHandler(mockRepo.Object);
+        return (handler, mockRepo);
+    }
+
+    #endregion
+
+    #region Happy Path Tests
+
+    /// <summary>
+    /// AC: ORD-001-AC-01
+    /// When a valid order is placed, a new Order aggregate is created with status Placed.
+    /// HTTP 201 is returned with orderId, orderNumber, status, and calculated total.
+    /// </summary>
+    [Fact]
+    public async Task PlaceOrder_WithValidData_ReturnsCreatedResultWithPlacedStatus()
+    {
+        // Arrange
+        var (handler, repo) = CreateHandler();
+        var command = CreateValidCommand();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.OrderId.Should().NotBeEmpty();
+        result.OrderNumber.Should().StartWith("ORD-");
+        result.Status.Should().Be("Placed");
+        result.OrderTotal.Should().Be(17.98m + 2.99m); // 2 x 8.99 + 2.99 delivery
+    }
+
+    /// <summary>
+    /// AC: ORD-001-AC-02
+    /// Order total is calculated as subtotal + GBP 2.99 delivery fee (ORD-R06).
+    /// </summary>
+    [Fact]
+    public async Task PlaceOrder_CalculatesOrderTotal_SubtotalPlusDeliveryFee()
+    {
+        // Arrange
+        var (handler, repo) = CreateHandler();
+        var command = CreateValidCommand(lineItems: new List<PlaceOrderLineItem>
+        {
+            new() { MenuItemId = Guid.NewGuid(), MenuItemName = "Item A", Quantity = 1, UnitPrice = 10.00m },
+            new() { MenuItemId = Guid.NewGuid(), MenuItemName = "Item B", Quantity = 2, UnitPrice = 5.00m }
+        });
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert - subtotal = 10.00 + (2 * 5.00) = 20.00; total = 20.00 + 2.99 = 22.99
+        result.OrderTotal.Should().Be(22.99m);
+    }
+
+    /// <summary>
+    /// AC: ORD-001-AC-03
+    /// The order is persisted to the repository (Cosmos DB) via SaveAsync.
+    /// </summary>
+    [Fact]
+    public async Task PlaceOrder_WithValidData_PersistsOrderViaRepository()
+    {
+        // Arrange
+        var (handler, repo) = CreateHandler();
+        var command = CreateValidCommand();
+
+        // Act
+        await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        repo.Verify(r => r.SaveAsync(It.Is<Order>(o =>
+            o.Status == OrderStatus.Placed &&
+            o.CustomerId == command.CustomerId &&
+            o.RestaurantId == command.RestaurantId
+        ), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// AC: ORD-001-AC-04
+    /// An OrderPlaced domain event is raised with correct payload when an order is created.
+    /// </summary>
+    [Fact]
+    public async Task PlaceOrder_WithValidData_RaisesOrderPlacedDomainEvent()
+    {
+        // Arrange
+        var customerId = Guid.NewGuid();
+        var restaurantId = Guid.NewGuid();
+        var menuItemId = Guid.NewGuid();
+        Order? savedOrder = null;
+
+        var mockRepo = new Mock<IOrderRepository>();
+        mockRepo.Setup(r => r.SaveAsync(It.IsAny<Order>(), It.IsAny<CancellationToken>()))
+            .Callback<Order, CancellationToken>((o, _) => savedOrder = o)
+            .Returns(Task.CompletedTask);
+
+        var handler = new PlaceOrderCommandHandler(mockRepo.Object);
+        var command = CreateValidCommand(
+            customerId: customerId,
+            restaurantId: restaurantId,
+            lineItems: new List<PlaceOrderLineItem>
+            {
+                new() { MenuItemId = menuItemId, MenuItemName = "Pizza", Quantity = 2, UnitPrice = 8.99m }
+            });
+
+        // Act
+        await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        savedOrder.Should().NotBeNull();
+        savedOrder!.DomainEvents.Should().HaveCount(1);
+        var domainEvent = savedOrder.DomainEvents[0].Should().BeOfType<OrderPlaced>().Subject;
+
+        domainEvent.OrderId.Should().Be(savedOrder.Id);
+        domainEvent.CustomerId.Should().Be(customerId);
+        domainEvent.RestaurantId.Should().Be(restaurantId);
+        domainEvent.LineItems.Should().HaveCount(1);
+        domainEvent.LineItems[0].MenuItemId.Should().Be(menuItemId);
+        domainEvent.LineItems[0].Quantity.Should().Be(2);
+        domainEvent.LineItems[0].UnitPrice.Should().Be(8.99m);
+        domainEvent.OrderTotal.Should().Be(20.97m);
+        domainEvent.PlacedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+        domainEvent.EventId.Should().NotBeEmpty();
+    }
+
+    /// <summary>
+    /// AC: ORD-001-AC-05
+    /// The order number is generated in format ORD-YYYYMMDD-sequential (ORD-R07).
+    /// </summary>
+    [Fact]
+    public async Task PlaceOrder_GeneratesOrderNumber_InCorrectFormat()
+    {
+        // Arrange
+        var (handler, repo) = CreateHandler();
+        var command = CreateValidCommand();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.OrderNumber.Should().MatchRegex(@"^ORD-\d{8}-[A-Z0-9]{6}$");
+    }
+
+    #endregion
+
+    #region Validation Error Tests
+
+    /// <summary>
+    /// AC: ORD-001-ERR-01
+    /// When order subtotal is below GBP 10.00 (ORD-R01), InvalidOrderException
+    /// is thrown with error code ORDER_MINIMUM_NOT_MET.
+    /// </summary>
+    [Fact]
+    public async Task PlaceOrder_WhenSubtotalBelowMinimum_ThrowsInvalidOrderException()
+    {
+        // Arrange
+        var (handler, repo) = CreateHandler();
+        var command = CreateValidCommand(lineItems: new List<PlaceOrderLineItem>
+        {
+            new() { MenuItemId = Guid.NewGuid(), MenuItemName = "Small Item", Quantity = 1, UnitPrice = 5.00m }
+        });
+
+        // Act
+        var act = async () => await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOrderException>()
+            .Where(ex => ex.ErrorCode == "ORDER_MINIMUM_NOT_MET");
+    }
+
+    /// <summary>
+    /// AC: ORD-001-ERR-02
+    /// When more than 20 line items are provided (ORD-R02), InvalidOrderException
+    /// is thrown with error code ORDER_TOO_MANY_ITEMS.
+    /// </summary>
+    [Fact]
+    public async Task PlaceOrder_WhenTooManyItems_ThrowsInvalidOrderException()
+    {
+        // Arrange
+        var (handler, repo) = CreateHandler();
+        var tooManyItems = Enumerable.Range(1, 21)
+            .Select(i => new PlaceOrderLineItem
+            {
+                MenuItemId = Guid.NewGuid(),
+                MenuItemName = $"Item {i}",
+                Quantity = 1,
+                UnitPrice = 1.00m
+            }).ToList();
+        var command = CreateValidCommand(lineItems: tooManyItems);
+
+        // Act
+        var act = async () => await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOrderException>()
+            .Where(ex => ex.ErrorCode == "ORDER_TOO_MANY_ITEMS");
+    }
+
+    /// <summary>
+    /// AC: ORD-001-ERR-03
+    /// When a line item has quantity less than 1, InvalidOrderException
+    /// is thrown with error code ORDER_INVALID_LINE_ITEM.
+    /// </summary>
+    [Fact]
+    public async Task PlaceOrder_WhenLineItemHasInvalidQuantity_ThrowsInvalidOrderException()
+    {
+        // Arrange
+        var (handler, repo) = CreateHandler();
+        var command = CreateValidCommand(lineItems: new List<PlaceOrderLineItem>
+        {
+            new() { MenuItemId = Guid.NewGuid(), MenuItemName = "Bad Item", Quantity = 0, UnitPrice = 10.00m }
+        });
+
+        // Act
+        var act = async () => await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOrderException>()
+            .Where(ex => ex.ErrorCode == "ORDER_INVALID_LINE_ITEM");
+    }
+
+    /// <summary>
+    /// AC: ORD-001-ERR-03
+    /// When a line item has unit price of zero or negative, InvalidOrderException
+    /// is thrown with error code ORDER_INVALID_LINE_ITEM.
+    /// </summary>
+    [Fact]
+    public async Task PlaceOrder_WhenLineItemHasInvalidPrice_ThrowsInvalidOrderException()
+    {
+        // Arrange
+        var (handler, repo) = CreateHandler();
+        var command = CreateValidCommand(lineItems: new List<PlaceOrderLineItem>
+        {
+            new() { MenuItemId = Guid.NewGuid(), MenuItemName = "Free Item", Quantity = 1, UnitPrice = 0m }
+        });
+
+        // Act
+        var act = async () => await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOrderException>()
+            .Where(ex => ex.ErrorCode == "ORDER_INVALID_LINE_ITEM");
+    }
+
+    /// <summary>
+    /// AC: ORD-001-ERR-04
+    /// When delivery address is missing latitude, InvalidOrderException
+    /// is thrown with error code ORDER_INVALID_ADDRESS.
+    /// </summary>
+    [Fact]
+    public async Task PlaceOrder_WhenAddressMissingLatitude_ThrowsInvalidOrderException()
+    {
+        // Arrange
+        var (handler, repo) = CreateHandler();
+        var command = CreateValidCommand(deliveryAddress: new PlaceOrderDeliveryAddress
+        {
+            Street = "123 High Street",
+            City = "London",
+            Postcode = "SW1A 1AA",
+            Latitude = null,
+            Longitude = -0.1278
+        });
+
+        // Act
+        var act = async () => await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOrderException>()
+            .Where(ex => ex.ErrorCode == "ORDER_INVALID_ADDRESS");
+    }
+
+    /// <summary>
+    /// AC: ORD-001-ERR-05
+    /// When customerId is an empty GUID, InvalidOrderException
+    /// is thrown with error code ORDER_INVALID_CUSTOMER.
+    /// </summary>
+    [Fact]
+    public async Task PlaceOrder_WhenCustomerIdIsEmpty_ThrowsInvalidOrderException()
+    {
+        // Arrange
+        var (handler, repo) = CreateHandler();
+        var command = CreateValidCommand(customerId: Guid.Empty);
+
+        // Act
+        var act = async () => await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOrderException>()
+            .Where(ex => ex.ErrorCode == "ORDER_INVALID_CUSTOMER");
+    }
+
+    /// <summary>
+    /// AC: ORD-001-ERR-06
+    /// When restaurantId is an empty GUID, InvalidOrderException
+    /// is thrown with error code ORDER_INVALID_RESTAURANT.
+    /// </summary>
+    [Fact]
+    public async Task PlaceOrder_WhenRestaurantIdIsEmpty_ThrowsInvalidOrderException()
+    {
+        // Arrange
+        var (handler, repo) = CreateHandler();
+        var command = CreateValidCommand(restaurantId: Guid.Empty);
+
+        // Act
+        var act = async () => await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOrderException>()
+            .Where(ex => ex.ErrorCode == "ORDER_INVALID_RESTAURANT");
+    }
+
+    /// <summary>
+    /// AC: ORD-001-EDGE-01
+    /// When the order subtotal is exactly GBP 10.00 (minimum threshold), the order
+    /// should be accepted and processed successfully.
+    /// </summary>
+    [Fact]
+    public async Task PlaceOrder_WhenSubtotalExactlyMinimum_Succeeds()
+    {
+        // Arrange
+        var (handler, repo) = CreateHandler();
+        var command = CreateValidCommand(lineItems: new List<PlaceOrderLineItem>
+        {
+            new() { MenuItemId = Guid.NewGuid(), MenuItemName = "Exact Min", Quantity = 1, UnitPrice = 10.00m }
+        });
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be("Placed");
+        result.OrderTotal.Should().Be(12.99m); // 10.00 + 2.99
+    }
+
+    #endregion
+
+    #region Aggregate-Level Tests
+
+    /// <summary>
+    /// AC: ORD-001-AC-01
+    /// The Order aggregate constructor sets the status to Placed and records
+    /// both CreatedAt and PlacedAt timestamps.
+    /// </summary>
+    [Fact]
+    public void OrderConstructor_SetsStatusToPlacedAndRecordsTimestamps()
+    {
+        // Arrange & Act
+        var order = new Order(
+            id: Guid.NewGuid(),
+            orderNumber: "ORD-20260303-ABC123",
+            customerId: Guid.NewGuid(),
+            restaurantId: Guid.NewGuid(),
+            lineItems: new List<OrderLineItem>
+            {
+                new(Guid.NewGuid(), "Pizza", 1, 12.00m)
+            },
+            deliveryAddress: new DeliveryAddress("123 High St", "London", "SW1A 1AA", 51.5074, -0.1278),
+            orderTotal: new OrderTotal(12.00m, 2.99m, 14.99m));
+
+        // Assert
+        order.Status.Should().Be(OrderStatus.Placed);
+        order.CreatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+        order.PlacedAt.Should().NotBeNull();
+        order.PlacedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    /// <summary>
+    /// AC: ORD-001-AC-04
+    /// The Order aggregate constructor raises an OrderPlaced domain event with
+    /// correct delivery address mapping.
+    /// </summary>
+    [Fact]
+    public void OrderConstructor_RaisesOrderPlacedEvent_WithDeliveryAddress()
+    {
+        // Arrange & Act
+        var order = new Order(
+            id: Guid.NewGuid(),
+            orderNumber: "ORD-20260303-ABC123",
+            customerId: Guid.NewGuid(),
+            restaurantId: Guid.NewGuid(),
+            lineItems: new List<OrderLineItem>
+            {
+                new(Guid.NewGuid(), "Pizza", 1, 12.00m)
+            },
+            deliveryAddress: new DeliveryAddress("42 Baker Street", "London", "NW1 6XE", 51.5237, -0.1585),
+            orderTotal: new OrderTotal(12.00m, 2.99m, 14.99m));
+
+        // Assert
+        order.DomainEvents.Should().HaveCount(1);
+        var evt = order.DomainEvents[0].Should().BeOfType<OrderPlaced>().Subject;
+        evt.DeliveryAddress.Street.Should().Be("42 Baker Street");
+        evt.DeliveryAddress.City.Should().Be("London");
+        evt.DeliveryAddress.Postcode.Should().Be("NW1 6XE");
+        evt.DeliveryAddress.Latitude.Should().Be(51.5237);
+        evt.DeliveryAddress.Longitude.Should().Be(-0.1585);
+    }
+
+    #endregion
+}

--- a/tests/Orders.Tests/Unit/ORD002Tests.cs
+++ b/tests/Orders.Tests/Unit/ORD002Tests.cs
@@ -1,0 +1,234 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Orders.Domain.Aggregates;
+using Orders.Domain.Commands;
+using Orders.Domain.Events;
+using Orders.Domain.Exceptions;
+using Orders.Domain.ValueObjects;
+using Orders.Functions;
+using Orders.Infrastructure.Repositories;
+using System.Net;
+using Xunit;
+
+namespace Orders.Tests.Unit;
+
+/// <summary>
+/// Unit tests for ORD-002: Cancel Order.
+/// Tests the Order aggregate Cancel() method, the CancelOrderCommandHandler, and the CancelOrderFunction.
+/// </summary>
+public class ORD002Tests
+{
+    #region Test Helpers
+
+    /// <summary>
+    /// Creates a test Order aggregate in the specified status.
+    /// Uses reflection to set the Status property for testing non-Placed states.
+    /// </summary>
+    private static Order CreateTestOrder(OrderStatus status = OrderStatus.Placed)
+    {
+        var order = new Order(
+            id: Guid.NewGuid(),
+            orderNumber: "ORD-20260303-001",
+            customerId: Guid.NewGuid(),
+            restaurantId: Guid.NewGuid(),
+            lineItems: new List<OrderLineItem>
+            {
+                new(
+                    menuItemId: Guid.NewGuid(),
+                    menuItemName: "Margherita Pizza",
+                    quantity: 2,
+                    unitPrice: 8.99m)
+            },
+            deliveryAddress: new DeliveryAddress("123 High Street", "London", "SW1A 1AA", 51.5074, -0.1278),
+            orderTotal: new OrderTotal(17.98m, 2.99m, 20.97m));
+
+        // If a different status is requested, use reflection to set it
+        if (status != OrderStatus.Placed)
+        {
+            var statusProperty = typeof(Order).GetProperty(nameof(Order.Status));
+            statusProperty!.SetValue(order, status);
+        }
+
+        return order;
+    }
+
+    #endregion
+
+    #region Aggregate-Level Tests
+
+    /// <summary>
+    /// AC: ORD-002-AC-01
+    /// When an order is in Placed status and Cancel() is called,
+    /// the status transitions to Cancelled.
+    /// </summary>
+    [Fact]
+    public void CancelOrder_WhenStatusIsPlaced_TransitionsToCancelled()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Placed);
+
+        // Act
+        order.Cancel();
+
+        // Assert
+        order.Status.Should().Be(OrderStatus.Cancelled);
+        order.CancelledAt.Should().NotBeNull();
+        order.CancelledAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    /// <summary>
+    /// AC: ORD-002-AC-03
+    /// When an order in Placed status is cancelled, an OrderCancelled domain event
+    /// is raised with the correct payload (orderId, orderNumber, restaurantId, cancelledAt).
+    /// </summary>
+    [Fact]
+    public void CancelOrder_WhenStatusIsPlaced_RaisesOrderCancelledEvent()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Placed);
+
+        // Act
+        order.Cancel();
+
+        // Assert
+        order.DomainEvents.Should().HaveCount(1);
+
+        var domainEvent = order.DomainEvents[0];
+        domainEvent.Should().BeOfType<OrderCancelled>();
+
+        var cancelledEvent = (OrderCancelled)domainEvent;
+        cancelledEvent.OrderId.Should().Be(order.Id);
+        cancelledEvent.OrderNumber.Should().Be(order.OrderNumber);
+        cancelledEvent.RestaurantId.Should().Be(order.RestaurantId);
+        cancelledEvent.CancelledAt.Should().Be(order.CancelledAt!.Value);
+        cancelledEvent.EventId.Should().NotBeEmpty();
+        cancelledEvent.OccurredAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    /// <summary>
+    /// AC: ORD-002-ERR-02
+    /// When an order is in Accepted status, Cancel() throws OrderCannotBeCancelledException.
+    /// Business rule ORD-R05: cancellation only permitted from Placed status.
+    /// </summary>
+    [Fact]
+    public void CancelOrder_WhenStatusIsAccepted_ThrowsOrderCannotBeCancelledException()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Accepted);
+
+        // Act
+        var act = () => order.Cancel();
+
+        // Assert
+        act.Should().Throw<OrderCannotBeCancelledException>()
+            .Where(ex => ex.OrderId == order.Id)
+            .Where(ex => ex.CurrentStatus == OrderStatus.Accepted)
+            .Where(ex => ex.ErrorCode == "ORDER_CANNOT_CANCEL");
+
+        // Verify aggregate state is completely unmodified after failed cancellation
+        order.Status.Should().Be(OrderStatus.Accepted);
+        order.CancelledAt.Should().BeNull();
+        order.DomainEvents.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// AC: ORD-002-ERR-02
+    /// When an order is in Delivered status, Cancel() throws OrderCannotBeCancelledException.
+    /// Terminal states must not allow cancellation.
+    /// </summary>
+    [Fact]
+    public void CancelOrder_WhenStatusIsDelivered_ThrowsOrderCannotBeCancelledException()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Delivered);
+
+        // Act
+        var act = () => order.Cancel();
+
+        // Assert
+        act.Should().Throw<OrderCannotBeCancelledException>()
+            .Where(ex => ex.OrderId == order.Id)
+            .Where(ex => ex.CurrentStatus == OrderStatus.Delivered)
+            .Where(ex => ex.ErrorCode == "ORDER_CANNOT_CANCEL");
+
+        // Verify aggregate state is completely unmodified after failed cancellation
+        order.Status.Should().Be(OrderStatus.Delivered);
+        order.CancelledAt.Should().BeNull();
+        order.DomainEvents.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region Handler-Level Tests
+
+    /// <summary>
+    /// AC: ORD-002-ERR-01
+    /// When the order does not exist in the repository, the handler throws OrderNotFoundException.
+    /// This maps to HTTP 404 at the function level.
+    /// </summary>
+    [Fact]
+    public async Task CancelOrder_WhenOrderNotFound_ThrowsOrderNotFoundException()
+    {
+        // Arrange
+        var mockRepository = new Mock<IOrderRepository>();
+        var orderId = Guid.NewGuid();
+
+        mockRepository
+            .Setup(r => r.GetByIdAsync(orderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Order?)null);
+
+        var handler = new CancelOrderCommandHandler(mockRepository.Object);
+        var command = new CancelOrderCommand { OrderId = orderId };
+
+        // Act
+        var act = async () => await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<OrderNotFoundException>()
+            .Where(ex => ex.OrderId == orderId)
+            .Where(ex => ex.ErrorCode == "ORDER_NOT_FOUND");
+    }
+
+    /// <summary>
+    /// AC: ORD-002-AC-04
+    /// When cancellation succeeds, the handler returns a CancelOrderResult with
+    /// the order's updated status set to Cancelled, along with orderId, orderNumber, and cancelledAt.
+    /// </summary>
+    [Fact]
+    public async Task CancelOrder_ReturnsUpdatedOrderWithCancelledStatus()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Placed);
+        var mockRepository = new Mock<IOrderRepository>();
+
+        mockRepository
+            .Setup(r => r.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        mockRepository
+            .Setup(r => r.SaveAsync(order, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var handler = new CancelOrderCommandHandler(mockRepository.Object);
+        var command = new CancelOrderCommand { OrderId = order.Id };
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.OrderId.Should().Be(order.Id);
+        result.OrderNumber.Should().Be(order.OrderNumber);
+        result.Status.Should().Be("Cancelled");
+        result.CancelledAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+
+        // Verify the repository was called to save
+        mockRepository.Verify(r => r.SaveAsync(order, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    #endregion
+}

--- a/tests/Orders.Tests/Unit/ORD003Tests.cs
+++ b/tests/Orders.Tests/Unit/ORD003Tests.cs
@@ -1,0 +1,224 @@
+using FluentAssertions;
+using Moq;
+using Orders.Domain.Aggregates;
+using Orders.Domain.Exceptions;
+using Orders.Domain.Queries;
+using Orders.Domain.ValueObjects;
+using Orders.Infrastructure.Repositories;
+using Xunit;
+
+namespace Orders.Tests.Unit;
+
+/// <summary>
+/// Unit tests for ORD-003: Get Order by ID.
+/// Tests the GetOrderQueryHandler mapping and error handling.
+/// </summary>
+public class ORD003Tests
+{
+    #region Test Helpers
+
+    private static readonly Guid TestCustomerId = Guid.NewGuid();
+    private static readonly Guid TestRestaurantId = Guid.NewGuid();
+    private static readonly Guid TestMenuItemId = Guid.NewGuid();
+
+    /// <summary>
+    /// Creates a test Order aggregate in Placed status with known data for assertion.
+    /// </summary>
+    private static Order CreateTestOrder(Guid? orderId = null)
+    {
+        return new Order(
+            id: orderId ?? Guid.NewGuid(),
+            orderNumber: "ORD-20260303-042",
+            customerId: TestCustomerId,
+            restaurantId: TestRestaurantId,
+            lineItems: new List<OrderLineItem>
+            {
+                new(
+                    menuItemId: TestMenuItemId,
+                    menuItemName: "Margherita Pizza",
+                    quantity: 2,
+                    unitPrice: 8.99m),
+                new(
+                    menuItemId: Guid.NewGuid(),
+                    menuItemName: "Garlic Bread",
+                    quantity: 1,
+                    unitPrice: 3.50m)
+            },
+            deliveryAddress: new DeliveryAddress("123 High Street", "London", "SW1A 1AA", 51.5074, -0.1278),
+            orderTotal: new OrderTotal(21.48m, 2.99m, 24.47m));
+    }
+
+    private static (GetOrderQueryHandler handler, Mock<IOrderRepository> repo) CreateHandler()
+    {
+        var mockRepo = new Mock<IOrderRepository>();
+        var handler = new GetOrderQueryHandler(mockRepo.Object);
+        return (handler, mockRepo);
+    }
+
+    #endregion
+
+    #region Happy Path Tests
+
+    /// <summary>
+    /// AC: ORD-003-AC-01, ORD-003-AC-02
+    /// When an order exists, the handler returns a GetOrderResponse with HTTP 200
+    /// containing the full order details: id, number, customer, restaurant, status.
+    /// </summary>
+    [Fact]
+    public async Task GetOrder_WhenOrderExists_ReturnsFullOrderDetails()
+    {
+        // Arrange
+        var order = CreateTestOrder();
+        var (handler, repo) = CreateHandler();
+
+        repo.Setup(r => r.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        var query = new GetOrderQuery { OrderId = order.Id };
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.OrderId.Should().Be(order.Id);
+        result.OrderNumber.Should().Be("ORD-20260303-042");
+        result.CustomerId.Should().Be(TestCustomerId);
+        result.RestaurantId.Should().Be(TestRestaurantId);
+        result.Status.Should().Be("Placed");
+    }
+
+    /// <summary>
+    /// AC: ORD-003-AC-01
+    /// The response includes all line items with correct menuItemId, name, quantity, and unit price.
+    /// </summary>
+    [Fact]
+    public async Task GetOrder_WhenOrderExists_ReturnsAllLineItems()
+    {
+        // Arrange
+        var order = CreateTestOrder();
+        var (handler, repo) = CreateHandler();
+
+        repo.Setup(r => r.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        var query = new GetOrderQuery { OrderId = order.Id };
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.LineItems.Should().HaveCount(2);
+
+        result.LineItems[0].MenuItemId.Should().Be(TestMenuItemId);
+        result.LineItems[0].MenuItemName.Should().Be("Margherita Pizza");
+        result.LineItems[0].Quantity.Should().Be(2);
+        result.LineItems[0].UnitPrice.Should().Be(8.99m);
+
+        result.LineItems[1].MenuItemName.Should().Be("Garlic Bread");
+        result.LineItems[1].Quantity.Should().Be(1);
+        result.LineItems[1].UnitPrice.Should().Be(3.50m);
+    }
+
+    /// <summary>
+    /// AC: ORD-003-AC-01
+    /// The response includes delivery address and order totals mapped correctly.
+    /// </summary>
+    [Fact]
+    public async Task GetOrder_WhenOrderExists_ReturnsDeliveryAddressAndTotals()
+    {
+        // Arrange
+        var order = CreateTestOrder();
+        var (handler, repo) = CreateHandler();
+
+        repo.Setup(r => r.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        var query = new GetOrderQuery { OrderId = order.Id };
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert - Delivery address
+        result.DeliveryAddress.Should().NotBeNull();
+        result.DeliveryAddress!.Street.Should().Be("123 High Street");
+        result.DeliveryAddress.City.Should().Be("London");
+        result.DeliveryAddress.Postcode.Should().Be("SW1A 1AA");
+        result.DeliveryAddress.Latitude.Should().Be(51.5074);
+        result.DeliveryAddress.Longitude.Should().Be(-0.1278);
+
+        // Assert - Order totals
+        result.OrderTotal.Should().NotBeNull();
+        result.OrderTotal!.Subtotal.Should().Be(21.48m);
+        result.OrderTotal.DeliveryFee.Should().Be(2.99m);
+        result.OrderTotal.Total.Should().Be(24.47m);
+    }
+
+    /// <summary>
+    /// AC: ORD-003-AC-01
+    /// The response includes all state transition timestamps. For a freshly placed order,
+    /// CreatedAt and PlacedAt are set; all other timestamps are null.
+    /// </summary>
+    [Fact]
+    public async Task GetOrder_WhenOrderExists_ReturnsTimestampsCorrectly()
+    {
+        // Arrange
+        var order = CreateTestOrder();
+        var (handler, repo) = CreateHandler();
+
+        repo.Setup(r => r.GetByIdAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        var query = new GetOrderQuery { OrderId = order.Id };
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Timestamps.Should().NotBeNull();
+        result.Timestamps.CreatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+        result.Timestamps.PlacedAt.Should().NotBeNull();
+        result.Timestamps.PlacedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+
+        // All other timestamps should be null for a freshly placed order
+        result.Timestamps.AcceptedAt.Should().BeNull();
+        result.Timestamps.PreparingAt.Should().BeNull();
+        result.Timestamps.ReadyForPickupAt.Should().BeNull();
+        result.Timestamps.InDeliveryAt.Should().BeNull();
+        result.Timestamps.DeliveredAt.Should().BeNull();
+        result.Timestamps.RejectedAt.Should().BeNull();
+        result.Timestamps.CancelledAt.Should().BeNull();
+    }
+
+    #endregion
+
+    #region Error Path Tests
+
+    /// <summary>
+    /// AC: ORD-003-ERR-01
+    /// When the order does not exist in the repository, the handler throws OrderNotFoundException.
+    /// This maps to HTTP 404 at the function level.
+    /// </summary>
+    [Fact]
+    public async Task GetOrder_WhenOrderNotFound_ThrowsOrderNotFoundException()
+    {
+        // Arrange
+        var orderId = Guid.NewGuid();
+        var (handler, repo) = CreateHandler();
+
+        repo.Setup(r => r.GetByIdAsync(orderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Order?)null);
+
+        var query = new GetOrderQuery { OrderId = orderId };
+
+        // Act
+        var act = async () => await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<OrderNotFoundException>()
+            .Where(ex => ex.OrderId == orderId)
+            .Where(ex => ex.ErrorCode == "ORDER_NOT_FOUND");
+    }
+
+    #endregion
+}

--- a/tests/Orders.Tests/Unit/ORD004Tests.cs
+++ b/tests/Orders.Tests/Unit/ORD004Tests.cs
@@ -1,0 +1,195 @@
+using FluentAssertions;
+using Moq;
+using Orders.Domain.Aggregates;
+using Orders.Domain.Queries;
+using Orders.Domain.ValueObjects;
+using Orders.Infrastructure.Repositories;
+using Xunit;
+
+namespace Orders.Tests.Unit;
+
+/// <summary>
+/// Unit tests for ORD-004: Get Orders by Customer.
+/// Tests the GetOrdersByCustomerQueryHandler mapping, pagination, and empty results.
+/// </summary>
+public class ORD004Tests
+{
+    #region Test Helpers
+
+    private static readonly Guid TestCustomerId = Guid.NewGuid();
+    private static readonly Guid TestRestaurantId = Guid.NewGuid();
+
+    /// <summary>
+    /// Creates a test Order aggregate with known data for assertion.
+    /// </summary>
+    private static Order CreateTestOrder(Guid? orderId = null, string orderNumber = "ORD-20260303-001")
+    {
+        return new Order(
+            id: orderId ?? Guid.NewGuid(),
+            orderNumber: orderNumber,
+            customerId: TestCustomerId,
+            restaurantId: TestRestaurantId,
+            lineItems: new List<OrderLineItem>
+            {
+                new(
+                    menuItemId: Guid.NewGuid(),
+                    menuItemName: "Margherita Pizza",
+                    quantity: 2,
+                    unitPrice: 8.99m)
+            },
+            deliveryAddress: new DeliveryAddress("123 High Street", "London", "SW1A 1AA", 51.5074, -0.1278),
+            orderTotal: new OrderTotal(17.98m, 2.99m, 20.97m));
+    }
+
+    private static (GetOrdersByCustomerQueryHandler handler, Mock<IOrderRepository> repo) CreateHandler()
+    {
+        var mockRepo = new Mock<IOrderRepository>();
+        var handler = new GetOrdersByCustomerQueryHandler(mockRepo.Object);
+        return (handler, mockRepo);
+    }
+
+    #endregion
+
+    #region Happy Path Tests
+
+    /// <summary>
+    /// AC: ORD-004-AC-01
+    /// When a customer has orders, the handler returns a list of order summaries
+    /// with correct orderId, orderNumber, total, status, and createdAt.
+    /// </summary>
+    [Fact]
+    public async Task GetOrdersByCustomer_WhenOrdersExist_ReturnsOrderSummaries()
+    {
+        // Arrange
+        var order1 = CreateTestOrder(orderNumber: "ORD-20260303-001");
+        var order2 = CreateTestOrder(orderNumber: "ORD-20260303-002");
+        var (handler, repo) = CreateHandler();
+
+        repo.Setup(r => r.GetByCustomerIdAsync(
+                TestCustomerId, null, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<Order> { order1, order2 }, (string?)null));
+
+        var query = new GetOrdersByCustomerQuery { CustomerId = TestCustomerId };
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Orders.Should().HaveCount(2);
+
+        result.Orders[0].OrderId.Should().Be(order1.Id);
+        result.Orders[0].OrderNumber.Should().Be("ORD-20260303-001");
+        result.Orders[0].Total.Should().Be(20.97m);
+        result.Orders[0].Status.Should().Be("Placed");
+        result.Orders[0].CreatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+
+        result.Orders[1].OrderId.Should().Be(order2.Id);
+        result.Orders[1].OrderNumber.Should().Be("ORD-20260303-002");
+    }
+
+    /// <summary>
+    /// AC: ORD-004-AC-02
+    /// When more results exist, the response includes a continuationToken for the next page.
+    /// </summary>
+    [Fact]
+    public async Task GetOrdersByCustomer_WhenMoreResultsExist_ReturnsContinuationToken()
+    {
+        // Arrange
+        var order = CreateTestOrder();
+        var expectedToken = "some-continuation-token";
+        var (handler, repo) = CreateHandler();
+
+        repo.Setup(r => r.GetByCustomerIdAsync(
+                TestCustomerId, null, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<Order> { order }, expectedToken));
+
+        var query = new GetOrdersByCustomerQuery { CustomerId = TestCustomerId };
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.ContinuationToken.Should().Be(expectedToken);
+    }
+
+    /// <summary>
+    /// AC: ORD-004-AC-02
+    /// When a continuation token is provided, it is passed through to the repository.
+    /// </summary>
+    [Fact]
+    public async Task GetOrdersByCustomer_WithContinuationToken_PassesTokenToRepository()
+    {
+        // Arrange
+        var (handler, repo) = CreateHandler();
+        var inputToken = "previous-page-token";
+
+        repo.Setup(r => r.GetByCustomerIdAsync(
+                TestCustomerId, inputToken, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<Order>(), (string?)null));
+
+        var query = new GetOrdersByCustomerQuery
+        {
+            CustomerId = TestCustomerId,
+            ContinuationToken = inputToken
+        };
+
+        // Act
+        await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        repo.Verify(r => r.GetByCustomerIdAsync(
+            TestCustomerId, inputToken, 20, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// AC: ORD-004-AC-03
+    /// When a customer has no orders, an empty list is returned with no continuation token.
+    /// </summary>
+    [Fact]
+    public async Task GetOrdersByCustomer_WhenNoOrders_ReturnsEmptyList()
+    {
+        // Arrange
+        var (handler, repo) = CreateHandler();
+
+        repo.Setup(r => r.GetByCustomerIdAsync(
+                TestCustomerId, null, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<Order>(), (string?)null));
+
+        var query = new GetOrdersByCustomerQuery { CustomerId = TestCustomerId };
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Orders.Should().BeEmpty();
+        result.ContinuationToken.Should().BeNull();
+    }
+
+    /// <summary>
+    /// AC: ORD-004-AC-01
+    /// When no more results exist, the continuationToken is null.
+    /// </summary>
+    [Fact]
+    public async Task GetOrdersByCustomer_WhenNoMoreResults_ContinuationTokenIsNull()
+    {
+        // Arrange
+        var order = CreateTestOrder();
+        var (handler, repo) = CreateHandler();
+
+        repo.Setup(r => r.GetByCustomerIdAsync(
+                TestCustomerId, null, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<Order> { order }, (string?)null));
+
+        var query = new GetOrdersByCustomerQuery { CustomerId = TestCustomerId };
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.ContinuationToken.Should().BeNull();
+    }
+
+    #endregion
+}

--- a/tests/Orders.Tests/Unit/ORD005Tests.cs
+++ b/tests/Orders.Tests/Unit/ORD005Tests.cs
@@ -1,0 +1,163 @@
+using FluentAssertions;
+using Orders.Domain.Aggregates;
+using Orders.Domain.Exceptions;
+using Orders.Domain.ValueObjects;
+using Xunit;
+
+namespace Orders.Tests.Unit;
+
+/// <summary>
+/// Unit tests for ORD-005: Handle OrderAccepted event.
+/// Tests the Order aggregate Accept() method including valid transitions,
+/// invalid transitions, and idempotency considerations.
+/// </summary>
+public class ORD005Tests
+{
+    #region Test Helpers
+
+    /// <summary>
+    /// Creates a test Order aggregate in the specified status.
+    /// Uses reflection to set the Status property for testing non-Placed states.
+    /// </summary>
+    private static Order CreateTestOrder(OrderStatus status = OrderStatus.Placed)
+    {
+        var order = new Order(
+            id: Guid.NewGuid(),
+            orderNumber: "ORD-20260303-001",
+            customerId: Guid.NewGuid(),
+            restaurantId: Guid.NewGuid(),
+            lineItems: new List<OrderLineItem>
+            {
+                new(
+                    menuItemId: Guid.NewGuid(),
+                    menuItemName: "Margherita Pizza",
+                    quantity: 2,
+                    unitPrice: 8.99m)
+            },
+            deliveryAddress: new DeliveryAddress("123 High Street", "London", "SW1A 1AA", 51.5074, -0.1278),
+            orderTotal: new OrderTotal(17.98m, 2.99m, 20.97m));
+
+        if (status != OrderStatus.Placed)
+        {
+            var statusProperty = typeof(Order).GetProperty(nameof(Order.Status));
+            statusProperty!.SetValue(order, status);
+        }
+
+        return order;
+    }
+
+    #endregion
+
+    #region Valid Transition Tests
+
+    /// <summary>
+    /// AC: ORD-005-AC-01
+    /// When an order is in Placed status and Accept() is called,
+    /// the status transitions to Accepted.
+    /// </summary>
+    [Fact]
+    public void Accept_WhenStatusIsPlaced_TransitionsToAccepted()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Placed);
+
+        // Act
+        order.Accept();
+
+        // Assert
+        order.Status.Should().Be(OrderStatus.Accepted);
+    }
+
+    /// <summary>
+    /// AC: ORD-005-AC-02
+    /// When an order is accepted, the AcceptedAt timestamp is recorded.
+    /// </summary>
+    [Fact]
+    public void Accept_WhenStatusIsPlaced_RecordsAcceptedAtTimestamp()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Placed);
+
+        // Act
+        order.Accept();
+
+        // Assert
+        order.AcceptedAt.Should().NotBeNull();
+        order.AcceptedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    #endregion
+
+    #region Invalid Transition Tests
+
+    /// <summary>
+    /// AC: ORD-005-ERR-01
+    /// When an order is in Cancelled status, Accept() throws InvalidOrderTransitionException.
+    /// The event handler catches this and logs a warning without rethrowing.
+    /// </summary>
+    [Fact]
+    public void Accept_WhenStatusIsCancelled_ThrowsInvalidOrderTransitionException()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Cancelled);
+
+        // Act
+        var act = () => order.Accept();
+
+        // Assert
+        act.Should().Throw<InvalidOrderTransitionException>()
+            .Where(ex => ex.OrderId == order.Id)
+            .Where(ex => ex.CurrentStatus == OrderStatus.Cancelled)
+            .Where(ex => ex.TargetStatus == OrderStatus.Accepted)
+            .Where(ex => ex.ErrorCode == "ORDER_INVALID_TRANSITION");
+
+        // Verify aggregate state is completely unmodified
+        order.Status.Should().Be(OrderStatus.Cancelled);
+        order.AcceptedAt.Should().BeNull();
+    }
+
+    /// <summary>
+    /// AC: ORD-005-ERR-01
+    /// When an order is in Rejected status, Accept() throws InvalidOrderTransitionException.
+    /// </summary>
+    [Fact]
+    public void Accept_WhenStatusIsRejected_ThrowsInvalidOrderTransitionException()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Rejected);
+
+        // Act
+        var act = () => order.Accept();
+
+        // Assert
+        act.Should().Throw<InvalidOrderTransitionException>()
+            .Where(ex => ex.CurrentStatus == OrderStatus.Rejected)
+            .Where(ex => ex.TargetStatus == OrderStatus.Accepted);
+
+        // Verify aggregate state is completely unmodified
+        order.Status.Should().Be(OrderStatus.Rejected);
+        order.AcceptedAt.Should().BeNull();
+    }
+
+    /// <summary>
+    /// AC: ORD-005-ERR-01
+    /// When an order is already Accepted, calling Accept() again throws
+    /// InvalidOrderTransitionException (idempotency handled at function level).
+    /// </summary>
+    [Fact]
+    public void Accept_WhenStatusIsAlreadyAccepted_ThrowsInvalidOrderTransitionException()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Accepted);
+
+        // Act
+        var act = () => order.Accept();
+
+        // Assert
+        act.Should().Throw<InvalidOrderTransitionException>()
+            .Where(ex => ex.CurrentStatus == OrderStatus.Accepted)
+            .Where(ex => ex.TargetStatus == OrderStatus.Accepted);
+    }
+
+    #endregion
+}

--- a/tests/Orders.Tests/Unit/ORD006Tests.cs
+++ b/tests/Orders.Tests/Unit/ORD006Tests.cs
@@ -1,0 +1,163 @@
+using FluentAssertions;
+using Orders.Domain.Aggregates;
+using Orders.Domain.Exceptions;
+using Orders.Domain.ValueObjects;
+using Xunit;
+
+namespace Orders.Tests.Unit;
+
+/// <summary>
+/// Unit tests for ORD-006: Handle OrderRejected event.
+/// Tests the Order aggregate Reject() method including valid transitions,
+/// invalid transitions, and state integrity after failed transitions.
+/// </summary>
+public class ORD006Tests
+{
+    #region Test Helpers
+
+    /// <summary>
+    /// Creates a test Order aggregate in the specified status.
+    /// Uses reflection to set the Status property for testing non-Placed states.
+    /// </summary>
+    private static Order CreateTestOrder(OrderStatus status = OrderStatus.Placed)
+    {
+        var order = new Order(
+            id: Guid.NewGuid(),
+            orderNumber: "ORD-20260303-001",
+            customerId: Guid.NewGuid(),
+            restaurantId: Guid.NewGuid(),
+            lineItems: new List<OrderLineItem>
+            {
+                new(
+                    menuItemId: Guid.NewGuid(),
+                    menuItemName: "Margherita Pizza",
+                    quantity: 2,
+                    unitPrice: 8.99m)
+            },
+            deliveryAddress: new DeliveryAddress("123 High Street", "London", "SW1A 1AA", 51.5074, -0.1278),
+            orderTotal: new OrderTotal(17.98m, 2.99m, 20.97m));
+
+        if (status != OrderStatus.Placed)
+        {
+            var statusProperty = typeof(Order).GetProperty(nameof(Order.Status));
+            statusProperty!.SetValue(order, status);
+        }
+
+        return order;
+    }
+
+    #endregion
+
+    #region Valid Transition Tests
+
+    /// <summary>
+    /// AC: ORD-006-AC-01
+    /// When an order is in Placed status and Reject() is called,
+    /// the status transitions to Rejected.
+    /// </summary>
+    [Fact]
+    public void Reject_WhenStatusIsPlaced_TransitionsToRejected()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Placed);
+
+        // Act
+        order.Reject("ITEM_UNAVAILABLE");
+
+        // Assert
+        order.Status.Should().Be(OrderStatus.Rejected);
+    }
+
+    /// <summary>
+    /// AC: ORD-006-AC-02
+    /// When an order is rejected, the RejectedAt timestamp is recorded.
+    /// </summary>
+    [Fact]
+    public void Reject_WhenStatusIsPlaced_RecordsRejectedAtTimestamp()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Placed);
+
+        // Act
+        order.Reject("TOO_BUSY");
+
+        // Assert
+        order.RejectedAt.Should().NotBeNull();
+        order.RejectedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    #endregion
+
+    #region Invalid Transition Tests
+
+    /// <summary>
+    /// AC: ORD-006-ERR-01
+    /// When an order is in Cancelled status, Reject() throws InvalidOrderTransitionException.
+    /// </summary>
+    [Fact]
+    public void Reject_WhenStatusIsCancelled_ThrowsInvalidOrderTransitionException()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Cancelled);
+
+        // Act
+        var act = () => order.Reject("TOO_BUSY");
+
+        // Assert
+        act.Should().Throw<InvalidOrderTransitionException>()
+            .Where(ex => ex.OrderId == order.Id)
+            .Where(ex => ex.CurrentStatus == OrderStatus.Cancelled)
+            .Where(ex => ex.TargetStatus == OrderStatus.Rejected)
+            .Where(ex => ex.ErrorCode == "ORDER_INVALID_TRANSITION");
+
+        // Verify aggregate state is completely unmodified
+        order.Status.Should().Be(OrderStatus.Cancelled);
+        order.RejectedAt.Should().BeNull();
+    }
+
+    /// <summary>
+    /// AC: ORD-006-ERR-01
+    /// When an order is in Accepted status, Reject() throws InvalidOrderTransitionException.
+    /// Once accepted, an order cannot be rejected.
+    /// </summary>
+    [Fact]
+    public void Reject_WhenStatusIsAccepted_ThrowsInvalidOrderTransitionException()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Accepted);
+
+        // Act
+        var act = () => order.Reject("TOO_BUSY");
+
+        // Assert
+        act.Should().Throw<InvalidOrderTransitionException>()
+            .Where(ex => ex.CurrentStatus == OrderStatus.Accepted)
+            .Where(ex => ex.TargetStatus == OrderStatus.Rejected);
+
+        // Verify aggregate state is completely unmodified
+        order.Status.Should().Be(OrderStatus.Accepted);
+        order.RejectedAt.Should().BeNull();
+    }
+
+    /// <summary>
+    /// AC: ORD-006-ERR-01
+    /// When an order is already Rejected, calling Reject() again throws
+    /// InvalidOrderTransitionException (idempotency handled at function level).
+    /// </summary>
+    [Fact]
+    public void Reject_WhenStatusIsAlreadyRejected_ThrowsInvalidOrderTransitionException()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Rejected);
+
+        // Act
+        var act = () => order.Reject("OTHER");
+
+        // Assert
+        act.Should().Throw<InvalidOrderTransitionException>()
+            .Where(ex => ex.CurrentStatus == OrderStatus.Rejected)
+            .Where(ex => ex.TargetStatus == OrderStatus.Rejected);
+    }
+
+    #endregion
+}

--- a/tests/Orders.Tests/Unit/ORD007Tests.cs
+++ b/tests/Orders.Tests/Unit/ORD007Tests.cs
@@ -1,0 +1,183 @@
+using FluentAssertions;
+using Orders.Domain.Aggregates;
+using Orders.Domain.Exceptions;
+using Orders.Domain.ValueObjects;
+using Xunit;
+
+namespace Orders.Tests.Unit;
+
+/// <summary>
+/// Unit tests for ORD-007: Handle OrderReadyForPickup event.
+/// Tests the Order aggregate MarkReadyForPickup() method including valid transitions
+/// from both Accepted and Preparing statuses, invalid transitions, and state integrity.
+/// </summary>
+public class ORD007Tests
+{
+    #region Test Helpers
+
+    /// <summary>
+    /// Creates a test Order aggregate in the specified status.
+    /// Uses reflection to set the Status property for testing non-Placed states.
+    /// </summary>
+    private static Order CreateTestOrder(OrderStatus status = OrderStatus.Accepted)
+    {
+        var order = new Order(
+            id: Guid.NewGuid(),
+            orderNumber: "ORD-20260303-001",
+            customerId: Guid.NewGuid(),
+            restaurantId: Guid.NewGuid(),
+            lineItems: new List<OrderLineItem>
+            {
+                new(
+                    menuItemId: Guid.NewGuid(),
+                    menuItemName: "Margherita Pizza",
+                    quantity: 2,
+                    unitPrice: 8.99m)
+            },
+            deliveryAddress: new DeliveryAddress("123 High Street", "London", "SW1A 1AA", 51.5074, -0.1278),
+            orderTotal: new OrderTotal(17.98m, 2.99m, 20.97m));
+
+        if (status != OrderStatus.Placed)
+        {
+            var statusProperty = typeof(Order).GetProperty(nameof(Order.Status));
+            statusProperty!.SetValue(order, status);
+        }
+
+        return order;
+    }
+
+    #endregion
+
+    #region Valid Transition Tests
+
+    /// <summary>
+    /// AC: ORD-007-AC-01
+    /// When an order is in Accepted status and MarkReadyForPickup() is called,
+    /// the status transitions to ReadyForPickup.
+    /// </summary>
+    [Fact]
+    public void MarkReadyForPickup_WhenStatusIsAccepted_TransitionsToReadyForPickup()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Accepted);
+
+        // Act
+        order.MarkReadyForPickup();
+
+        // Assert
+        order.Status.Should().Be(OrderStatus.ReadyForPickup);
+    }
+
+    /// <summary>
+    /// AC: ORD-007-AC-01
+    /// When an order is in Preparing status and MarkReadyForPickup() is called,
+    /// the status transitions to ReadyForPickup. This handles the case where
+    /// the Order context may not have received an intermediate Preparing status update.
+    /// </summary>
+    [Fact]
+    public void MarkReadyForPickup_WhenStatusIsPreparing_TransitionsToReadyForPickup()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Preparing);
+
+        // Act
+        order.MarkReadyForPickup();
+
+        // Assert
+        order.Status.Should().Be(OrderStatus.ReadyForPickup);
+    }
+
+    /// <summary>
+    /// AC: ORD-007-AC-02
+    /// When an order is marked ready for pickup, the ReadyForPickupAt timestamp is recorded.
+    /// </summary>
+    [Fact]
+    public void MarkReadyForPickup_WhenValid_RecordsReadyForPickupAtTimestamp()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Accepted);
+
+        // Act
+        order.MarkReadyForPickup();
+
+        // Assert
+        order.ReadyForPickupAt.Should().NotBeNull();
+        order.ReadyForPickupAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    #endregion
+
+    #region Invalid Transition Tests
+
+    /// <summary>
+    /// AC: ORD-007-ERR-01
+    /// When an order is in Placed status, MarkReadyForPickup() throws
+    /// InvalidOrderTransitionException. An order must be Accepted before it can be ready.
+    /// </summary>
+    [Fact]
+    public void MarkReadyForPickup_WhenStatusIsPlaced_ThrowsInvalidOrderTransitionException()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Placed);
+
+        // Act
+        var act = () => order.MarkReadyForPickup();
+
+        // Assert
+        act.Should().Throw<InvalidOrderTransitionException>()
+            .Where(ex => ex.OrderId == order.Id)
+            .Where(ex => ex.CurrentStatus == OrderStatus.Placed)
+            .Where(ex => ex.TargetStatus == OrderStatus.ReadyForPickup)
+            .Where(ex => ex.ErrorCode == "ORDER_INVALID_TRANSITION");
+
+        // Verify aggregate state is completely unmodified
+        order.Status.Should().Be(OrderStatus.Placed);
+        order.ReadyForPickupAt.Should().BeNull();
+    }
+
+    /// <summary>
+    /// AC: ORD-007-ERR-01
+    /// When an order is in Cancelled status, MarkReadyForPickup() throws
+    /// InvalidOrderTransitionException.
+    /// </summary>
+    [Fact]
+    public void MarkReadyForPickup_WhenStatusIsCancelled_ThrowsInvalidOrderTransitionException()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Cancelled);
+
+        // Act
+        var act = () => order.MarkReadyForPickup();
+
+        // Assert
+        act.Should().Throw<InvalidOrderTransitionException>()
+            .Where(ex => ex.CurrentStatus == OrderStatus.Cancelled)
+            .Where(ex => ex.TargetStatus == OrderStatus.ReadyForPickup);
+
+        // Verify aggregate state is completely unmodified
+        order.Status.Should().Be(OrderStatus.Cancelled);
+        order.ReadyForPickupAt.Should().BeNull();
+    }
+
+    /// <summary>
+    /// AC: ORD-007-ERR-01
+    /// When an order is in Rejected status, MarkReadyForPickup() throws
+    /// InvalidOrderTransitionException.
+    /// </summary>
+    [Fact]
+    public void MarkReadyForPickup_WhenStatusIsRejected_ThrowsInvalidOrderTransitionException()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Rejected);
+
+        // Act
+        var act = () => order.MarkReadyForPickup();
+
+        // Assert
+        act.Should().Throw<InvalidOrderTransitionException>()
+            .Where(ex => ex.CurrentStatus == OrderStatus.Rejected)
+            .Where(ex => ex.TargetStatus == OrderStatus.ReadyForPickup);
+    }
+
+    #endregion
+}

--- a/tests/Orders.Tests/Unit/ORD008Tests.cs
+++ b/tests/Orders.Tests/Unit/ORD008Tests.cs
@@ -1,0 +1,164 @@
+using FluentAssertions;
+using Orders.Domain.Aggregates;
+using Orders.Domain.Exceptions;
+using Orders.Domain.ValueObjects;
+using Xunit;
+
+namespace Orders.Tests.Unit;
+
+/// <summary>
+/// Unit tests for ORD-008: Handle DriverAssigned event.
+/// Tests the Order aggregate MarkInDelivery() method including valid transitions,
+/// invalid transitions, and state integrity after failed transitions.
+/// </summary>
+public class ORD008Tests
+{
+    #region Test Helpers
+
+    /// <summary>
+    /// Creates a test Order aggregate in the specified status.
+    /// Uses reflection to set the Status property for testing non-Placed states.
+    /// </summary>
+    private static Order CreateTestOrder(OrderStatus status = OrderStatus.ReadyForPickup)
+    {
+        var order = new Order(
+            id: Guid.NewGuid(),
+            orderNumber: "ORD-20260303-001",
+            customerId: Guid.NewGuid(),
+            restaurantId: Guid.NewGuid(),
+            lineItems: new List<OrderLineItem>
+            {
+                new(
+                    menuItemId: Guid.NewGuid(),
+                    menuItemName: "Margherita Pizza",
+                    quantity: 2,
+                    unitPrice: 8.99m)
+            },
+            deliveryAddress: new DeliveryAddress("123 High Street", "London", "SW1A 1AA", 51.5074, -0.1278),
+            orderTotal: new OrderTotal(17.98m, 2.99m, 20.97m));
+
+        if (status != OrderStatus.Placed)
+        {
+            var statusProperty = typeof(Order).GetProperty(nameof(Order.Status));
+            statusProperty!.SetValue(order, status);
+        }
+
+        return order;
+    }
+
+    #endregion
+
+    #region Valid Transition Tests
+
+    /// <summary>
+    /// AC: ORD-008-AC-01
+    /// When an order is in ReadyForPickup status and MarkInDelivery() is called,
+    /// the status transitions to InDelivery.
+    /// </summary>
+    [Fact]
+    public void MarkInDelivery_WhenStatusIsReadyForPickup_TransitionsToInDelivery()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.ReadyForPickup);
+
+        // Act
+        order.MarkInDelivery();
+
+        // Assert
+        order.Status.Should().Be(OrderStatus.InDelivery);
+    }
+
+    /// <summary>
+    /// AC: ORD-008-AC-02
+    /// When an order is marked in delivery, the InDeliveryAt timestamp is recorded.
+    /// </summary>
+    [Fact]
+    public void MarkInDelivery_WhenValid_RecordsInDeliveryAtTimestamp()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.ReadyForPickup);
+
+        // Act
+        order.MarkInDelivery();
+
+        // Assert
+        order.InDeliveryAt.Should().NotBeNull();
+        order.InDeliveryAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    #endregion
+
+    #region Invalid Transition Tests
+
+    /// <summary>
+    /// AC: ORD-008-ERR-01
+    /// When an order is in Accepted status, MarkInDelivery() throws
+    /// InvalidOrderTransitionException. An order must be ReadyForPickup first.
+    /// </summary>
+    [Fact]
+    public void MarkInDelivery_WhenStatusIsAccepted_ThrowsInvalidOrderTransitionException()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Accepted);
+
+        // Act
+        var act = () => order.MarkInDelivery();
+
+        // Assert
+        act.Should().Throw<InvalidOrderTransitionException>()
+            .Where(ex => ex.OrderId == order.Id)
+            .Where(ex => ex.CurrentStatus == OrderStatus.Accepted)
+            .Where(ex => ex.TargetStatus == OrderStatus.InDelivery)
+            .Where(ex => ex.ErrorCode == "ORDER_INVALID_TRANSITION");
+
+        // Verify aggregate state is completely unmodified
+        order.Status.Should().Be(OrderStatus.Accepted);
+        order.InDeliveryAt.Should().BeNull();
+    }
+
+    /// <summary>
+    /// AC: ORD-008-ERR-01
+    /// When an order is in Placed status, MarkInDelivery() throws
+    /// InvalidOrderTransitionException.
+    /// </summary>
+    [Fact]
+    public void MarkInDelivery_WhenStatusIsPlaced_ThrowsInvalidOrderTransitionException()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Placed);
+
+        // Act
+        var act = () => order.MarkInDelivery();
+
+        // Assert
+        act.Should().Throw<InvalidOrderTransitionException>()
+            .Where(ex => ex.CurrentStatus == OrderStatus.Placed)
+            .Where(ex => ex.TargetStatus == OrderStatus.InDelivery);
+
+        // Verify aggregate state is completely unmodified
+        order.Status.Should().Be(OrderStatus.Placed);
+        order.InDeliveryAt.Should().BeNull();
+    }
+
+    /// <summary>
+    /// AC: ORD-008-ERR-01
+    /// When an order is already InDelivery, calling MarkInDelivery() again throws
+    /// InvalidOrderTransitionException (idempotency handled at function level).
+    /// </summary>
+    [Fact]
+    public void MarkInDelivery_WhenStatusIsAlreadyInDelivery_ThrowsInvalidOrderTransitionException()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.InDelivery);
+
+        // Act
+        var act = () => order.MarkInDelivery();
+
+        // Assert
+        act.Should().Throw<InvalidOrderTransitionException>()
+            .Where(ex => ex.CurrentStatus == OrderStatus.InDelivery)
+            .Where(ex => ex.TargetStatus == OrderStatus.InDelivery);
+    }
+
+    #endregion
+}

--- a/tests/Orders.Tests/Unit/ORD009Tests.cs
+++ b/tests/Orders.Tests/Unit/ORD009Tests.cs
@@ -1,0 +1,189 @@
+using FluentAssertions;
+using Orders.Domain.Aggregates;
+using Orders.Domain.Exceptions;
+using Orders.Domain.ValueObjects;
+using Xunit;
+
+namespace Orders.Tests.Unit;
+
+/// <summary>
+/// Unit tests for ORD-009: Handle DeliveryCompleted event.
+/// Tests the Order aggregate MarkDelivered() method including valid transitions,
+/// invalid transitions, and state integrity after failed transitions.
+/// This is the terminal happy-path transition for an order.
+/// </summary>
+public class ORD009Tests
+{
+    #region Test Helpers
+
+    /// <summary>
+    /// Creates a test Order aggregate in the specified status.
+    /// Uses reflection to set the Status property for testing non-Placed states.
+    /// </summary>
+    private static Order CreateTestOrder(OrderStatus status = OrderStatus.InDelivery)
+    {
+        var order = new Order(
+            id: Guid.NewGuid(),
+            orderNumber: "ORD-20260303-001",
+            customerId: Guid.NewGuid(),
+            restaurantId: Guid.NewGuid(),
+            lineItems: new List<OrderLineItem>
+            {
+                new(
+                    menuItemId: Guid.NewGuid(),
+                    menuItemName: "Margherita Pizza",
+                    quantity: 2,
+                    unitPrice: 8.99m)
+            },
+            deliveryAddress: new DeliveryAddress("123 High Street", "London", "SW1A 1AA", 51.5074, -0.1278),
+            orderTotal: new OrderTotal(17.98m, 2.99m, 20.97m));
+
+        if (status != OrderStatus.Placed)
+        {
+            var statusProperty = typeof(Order).GetProperty(nameof(Order.Status));
+            statusProperty!.SetValue(order, status);
+        }
+
+        return order;
+    }
+
+    #endregion
+
+    #region Valid Transition Tests
+
+    /// <summary>
+    /// AC: ORD-009-AC-01
+    /// When an order is in InDelivery status and MarkDelivered() is called,
+    /// the status transitions to Delivered.
+    /// </summary>
+    [Fact]
+    public void MarkDelivered_WhenStatusIsInDelivery_TransitionsToDelivered()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.InDelivery);
+
+        // Act
+        order.MarkDelivered();
+
+        // Assert
+        order.Status.Should().Be(OrderStatus.Delivered);
+    }
+
+    /// <summary>
+    /// AC: ORD-009-AC-02
+    /// When an order is marked delivered, the DeliveredAt timestamp is recorded.
+    /// </summary>
+    [Fact]
+    public void MarkDelivered_WhenValid_RecordsDeliveredAtTimestamp()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.InDelivery);
+
+        // Act
+        order.MarkDelivered();
+
+        // Assert
+        order.DeliveredAt.Should().NotBeNull();
+        order.DeliveredAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    #endregion
+
+    #region Invalid Transition Tests
+
+    /// <summary>
+    /// AC: ORD-009-ERR-01
+    /// When an order is in ReadyForPickup status, MarkDelivered() throws
+    /// InvalidOrderTransitionException. An order must be InDelivery first.
+    /// </summary>
+    [Fact]
+    public void MarkDelivered_WhenStatusIsReadyForPickup_ThrowsInvalidOrderTransitionException()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.ReadyForPickup);
+
+        // Act
+        var act = () => order.MarkDelivered();
+
+        // Assert
+        act.Should().Throw<InvalidOrderTransitionException>()
+            .Where(ex => ex.OrderId == order.Id)
+            .Where(ex => ex.CurrentStatus == OrderStatus.ReadyForPickup)
+            .Where(ex => ex.TargetStatus == OrderStatus.Delivered)
+            .Where(ex => ex.ErrorCode == "ORDER_INVALID_TRANSITION");
+
+        // Verify aggregate state is completely unmodified
+        order.Status.Should().Be(OrderStatus.ReadyForPickup);
+        order.DeliveredAt.Should().BeNull();
+    }
+
+    /// <summary>
+    /// AC: ORD-009-ERR-01
+    /// When an order is in Placed status, MarkDelivered() throws
+    /// InvalidOrderTransitionException.
+    /// </summary>
+    [Fact]
+    public void MarkDelivered_WhenStatusIsPlaced_ThrowsInvalidOrderTransitionException()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Placed);
+
+        // Act
+        var act = () => order.MarkDelivered();
+
+        // Assert
+        act.Should().Throw<InvalidOrderTransitionException>()
+            .Where(ex => ex.CurrentStatus == OrderStatus.Placed)
+            .Where(ex => ex.TargetStatus == OrderStatus.Delivered);
+
+        // Verify aggregate state is completely unmodified
+        order.Status.Should().Be(OrderStatus.Placed);
+        order.DeliveredAt.Should().BeNull();
+    }
+
+    /// <summary>
+    /// AC: ORD-009-ERR-01
+    /// When an order is already Delivered, calling MarkDelivered() again throws
+    /// InvalidOrderTransitionException (idempotency handled at function level).
+    /// </summary>
+    [Fact]
+    public void MarkDelivered_WhenStatusIsAlreadyDelivered_ThrowsInvalidOrderTransitionException()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Delivered);
+
+        // Act
+        var act = () => order.MarkDelivered();
+
+        // Assert
+        act.Should().Throw<InvalidOrderTransitionException>()
+            .Where(ex => ex.CurrentStatus == OrderStatus.Delivered)
+            .Where(ex => ex.TargetStatus == OrderStatus.Delivered);
+    }
+
+    /// <summary>
+    /// AC: ORD-009-ERR-01
+    /// When an order is in Cancelled status, MarkDelivered() throws
+    /// InvalidOrderTransitionException.
+    /// </summary>
+    [Fact]
+    public void MarkDelivered_WhenStatusIsCancelled_ThrowsInvalidOrderTransitionException()
+    {
+        // Arrange
+        var order = CreateTestOrder(OrderStatus.Cancelled);
+
+        // Act
+        var act = () => order.MarkDelivered();
+
+        // Assert
+        act.Should().Throw<InvalidOrderTransitionException>()
+            .Where(ex => ex.CurrentStatus == OrderStatus.Cancelled)
+            .Where(ex => ex.TargetStatus == OrderStatus.Delivered);
+
+        // Verify aggregate state is completely unmodified
+        order.Status.Should().Be(OrderStatus.Cancelled);
+        order.DeliveredAt.Should().BeNull();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Implements the **Orders** bounded context with all 9 stories (ORD-001 through ORD-009)
- Order aggregate with full 9-state lifecycle (Draft → Placed → Accepted → ReadyForPickup → InDelivery → Delivered, plus Cancelled/Rejected)
- 4 HTTP functions (PlaceOrder, CancelOrder, GetOrder, GetOrdersByCustomer)
- 5 Service Bus event handlers consuming from Restaurant and Delivery contexts
- Cosmos DB repository with transactional outbox pattern and ETag concurrency
- 9 unit test files with 46 tests

## Stories
| Story | Type | Description |
|-------|------|-------------|
| ORD-001 | Command | Place a new food order with validated line items |
| ORD-002 | Command | Cancel an order before restaurant acceptance |
| ORD-003 | Query | Retrieve full order details by order ID |
| ORD-004 | Query | Retrieve paginated order history for a customer |
| ORD-005 | Event Handler | Handle OrderAccepted → Accepted |
| ORD-006 | Event Handler | Handle OrderRejected → Rejected |
| ORD-007 | Event Handler | Handle OrderReadyForPickup → ReadyForPickup |
| ORD-008 | Event Handler | Handle DriverAssigned → InDelivery |
| ORD-009 | Event Handler | Handle DeliveryCompleted → Delivered |

## Test plan
- [ ] All 46 unit tests pass
- [ ] Order aggregate state transitions verified
- [ ] Business rule validation (£10 min, 20 items max, line item validation)
- [ ] Event handler idempotency verified
- [ ] Zero side-effects on rejected transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Linked Issues
Closes #1
Closes #2
Closes #3
Closes #4
Closes #5
Closes #6
Closes #7
Closes #8
Closes #9